### PR TITLE
fix: prevent integer overflow in board size validation

### DIFF
--- a/board.go
+++ b/board.go
@@ -183,7 +183,15 @@ func (b *Board) isValidSquare(square string) bool {
 	}
 
 	col := square[0]
-	if col < 'a' || b.Size > 255 || col >= byte('a')+byte(b.Size) {
+	if col < 'a' {
+		return false
+	}
+	
+	if b.Size > 255 || int64('a')+b.Size > 255 {
+		return false
+	}
+	
+	if col >= byte('a')+byte(b.Size) {
 		return false
 	}
 

--- a/board.go
+++ b/board.go
@@ -183,7 +183,7 @@ func (b *Board) isValidSquare(square string) bool {
 	}
 
 	col := square[0]
-	if col < 'a' || col >= byte('a')+byte(b.Size) {
+	if col < 'a' || b.Size > 255 || col >= byte('a')+byte(b.Size) {
 		return false
 	}
 

--- a/board_test.go
+++ b/board_test.go
@@ -173,3 +173,35 @@ func TestIsEdge(t *testing.T) {
 func TestFindRoad(t *testing.T) {
 	// TODO: Write a test using TPS
 }
+
+func TestValidSquareIntegerOverflowPrevention(t *testing.T) {
+	b := &Board{
+		Size: 256,
+	}
+	_ = b.Init()
+
+	if b.isValidSquare("a1") {
+		t.Errorf("isValidSquare should return false for board size > 255 to prevent integer overflow")
+	}
+
+	b.Size = 159
+	if b.isValidSquare("a1") {
+		t.Errorf("isValidSquare should return false for board size that would cause overflow ('a' + size > 255)")
+	}
+
+	b.Size = 158
+	if !b.isValidSquare("a1") {
+		t.Errorf("isValidSquare should return true for board size that doesn't cause overflow")
+	}
+
+	b.Size = 9
+	if !b.isValidSquare("a1") {
+		t.Errorf("isValidSquare should return true for normal board size")
+	}
+	if !b.isValidSquare("i9") {
+		t.Errorf("isValidSquare should return true for valid square at max board size")
+	}
+	if b.isValidSquare("j1") {
+		t.Errorf("isValidSquare should return false for column beyond board size")
+	}
+}


### PR DESCRIPTION
## Summary
• Fix CodeQL security alert #8 - incorrect integer conversion vulnerability
• Add bounds checking to prevent unsafe int64 to uint8 conversion in `isValidSquare()`
• Add comprehensive test coverage for security edge cases

## Test plan
- [x] All existing tests pass
- [x] New security test covers overflow prevention
- [x] Edge cases tested for maximum safe board sizes
- [x] Normal board operations preserved

🤖 Generated with [Claude Code](https://claude.ai/code)