### PR TITLE
Convert Dockerfile to multi-stage build with non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,31 @@
-FROM golang:1.26-alpine
+FROM golang:1.26-alpine AS builder
 
 ENV GOPROXY="https://proxy.golang.org"
-ENV GO111MODULE="on"
+ENV CGO_ENABLED=0
+
+WORKDIR /app
+
+# Cache dependency downloads separately from source changes.
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN go build -ldflags="-s -w" -o /server ./cmd/server
+
+# ── Runtime image ─────────────────────────────────────────────────────────────
+FROM alpine:3.21
+
+RUN apk add --no-cache ca-certificates tzdata
+
 ENV NAT_ENV="production"
 ENV PORT="8080"
 
 EXPOSE 8080
 
-WORKDIR /go/src/github.com/icco/gotak
-RUN apk add --no-cache git
+# Run as a non-root user.
+RUN adduser -S -u 1001 app
+USER app
 
-COPY . .
+COPY --from=builder /server /server
 
-RUN go build -o /go/bin/server ./cmd/server
-
-CMD ["/go/bin/server"]
+CMD ["/server"]


### PR DESCRIPTION
## Problem

The `Dockerfile` was a single-stage build:

```dockerfile
FROM golang:1.26-alpine
# ...
RUN go build -o /go/bin/server ./cmd/server
CMD ["/go/bin/server"]
```

This means the **final container image includes**:
- The full Go compiler and standard library toolchain (~300 MB)
- `git` and Alpine build utilities
- All Go source code, module cache, and build artifacts
- The container runs as **root** (no `USER` instruction)

This dramatically expands the attack surface: if the application is exploited, an attacker has access to a full build environment and runs as root.

## Root cause

No multi-stage build was configured. The build and runtime environments were not separated.

## Fix

Split into two stages:

1. **`builder`** (`golang:1.26-alpine`) — compiles the binary with dependency caching and debug-symbol stripping (`-ldflags="-s -w"`)
2. **`runner`** (`alpine:3.21`) — minimal image containing only `ca-certificates`, `tzdata`, and the compiled binary

Additional improvements:
- `go mod download` is run in a separate layer before `COPY . .` so the dependency layer is cached across source-only changes
- A non-root system user (`app`, uid 1001) is added and set with `USER app`
- `ca-certificates` ensures TLS connections work; `tzdata` ensures time-zone handling works

## Impact

| Metric | Before | After |
|--------|--------|-------|
| Final image size | ~300 MB+ (full Go toolchain) | ~15–20 MB (Alpine + binary) |
| Runs as root | Yes | No (uid 1001) |
| Go toolchain in final image | Yes | No |
| Dependency layer cached | No | Yes |

## Testing steps

1. `docker build -t gotak .` — image should build successfully
2. `docker run --rm -e PORT=8080 -p 8080:8080 gotak` — server should start and respond
3. `docker run --rm gotak id` — should print `uid=1001(app)` (non-root)
4. `docker images gotak` — verify image size is significantly reduced

## What was reviewed / skipped this run

| Area | Finding | Action |
|------|---------|--------|
| Dockerfile | Single-stage build, runs as root | **Fixed (this PR)** |
| `go.mod` | All dependencies appear current (Go 1.25) | No action needed |
| JWT auth (`github.com/golang-jwt/jwt/v5 v5.3.1`) | Current version, no known CVEs | No action needed |
| CORS / security middleware | `go-chi/cors` + `unrolled/secure` present | No action needed |
| Tests | Good test coverage present (`board_test.go`, `game_test.go`, etc.) | No action needed |
| CI | Not audited this run | Future run |
