### PR TITLE
Upgrade runtime base image from alpine:3.21 to alpine:3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY . .
 RUN go build -ldflags="-s -w" -o /server ./cmd/server
 
 # ── Runtime image ─────────────────────────────────────────────────────────────
-FROM alpine:3.21
+FROM alpine:3.22
 
 RUN apk add --no-cache ca-certificates tzdata
 


### PR DESCRIPTION
## Problem

The final runtime stage used `alpine:3.21` (released November 2024), which has been superseded by `alpine:3.22` (May 2025). Alpine 3.21 is missing security patches included in 3.22.

## Fix

```diff
-FROM alpine:3.21
+FROM alpine:3.22
```

Single-line bump. Non-root user and other hygiene were already in place.

## Testing

```bash
docker build -t gotak-test .
docker run --rm gotak-test id
# uid=1001(app) gid=65533(nogroup) ...
```

## Audit Note

**Reviewed**: Dockerfile, go.mod, board.go, game.go, cmd/  
**Found & fixed**: outdated alpine:3.21 base image  
**Already good**: non-root user (app, UID 1001), multi-stage build, `.golangci.yml` and `.yamllint.yml` present, extensive test coverage  
**Skipped / future run**: all good here; this repo is well maintained
