### PR TITLE
Fix CORS bypass: set AllowCredentials=false when AllowedOrigins is wildcard

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -78,7 +78,14 @@ func main() {
 	}
 
 	r.Use(cors.New(cors.Options{
-		AllowCredentials:   true,
+		// AllowCredentials must be false when AllowedOrigins is ["*"].
+		// Combining a wildcard origin with credentials causes go-chi/cors to
+		// reflect the incoming Origin header, allowing any site to make
+		// credentialed cross-origin requests (CORS bypass, CWE-942).
+		// GoTak uses JWT tokens passed as Authorization headers rather than
+		// cookies, so AllowCredentials:false does not break authentication —
+		// Authorization headers are always forwarded regardless of this flag.
+		AllowCredentials:   false,
 		OptionsPassthrough: true,
 		AllowedOrigins:     []string{"*"},
 		AllowedMethods:     []string{"GET", "POST", "OPTIONS"},


### PR DESCRIPTION
## Problem

`cmd/server/main.go` configures CORS with `AllowCredentials: true` alongside `AllowedOrigins: []string{"*"}`:

```go
// BEFORE (vulnerable)
r.Use(cors.New(cors.Options{
    AllowCredentials:   true,   // ← dangerous with wildcard origin
    AllowedOrigins:     []string{"*"},
    ...
}).Handler)
```

The CORS specification prohibits `Access-Control-Allow-Origin: *` combined with `Access-Control-Allow-Credentials: true`. To work around it, `go-chi/cors` **reflects the incoming `Origin` header** when credentials are enabled — responding with `Access-Control-Allow-Origin: <attacker.com>` and `Access-Control-Allow-Credentials: true`.

This means **any website** can make credentialed cross-origin requests to `gotak.app`:

```javascript
// Any malicious page can do this
fetch('https://gotak.app/game/new', {
  method: 'POST',
  credentials: 'include',
  headers: { 'Authorization': 'Bearer <victim_token>' }
})
```

Because GoTak has **JWT authentication** and **authenticated mutation endpoints** (`POST /game/new`, `POST /game/{slug}/join`, `POST /game/{slug}/move`), the effective impact is that a cross-origin page could submit moves or create games on behalf of any victim whose token it can access. (CWE-942, Medium–High severity)

## Fix

Set `AllowCredentials: false`. GoTak passes JWT tokens in the `Authorization` header. HTTP request headers listed in `AllowedHeaders` are always forwarded in cross-origin requests regardless of `AllowCredentials`. There is **no functional change** to how JWT authentication works.

```go
// AFTER (safe)
r.Use(cors.New(cors.Options{
    AllowCredentials:   false,  // ← correct; does not break JWT auth
    AllowedOrigins:     []string{"*"},
    ...
}).Handler)
```

A comment has been added explaining why `false` is correct here so future maintainers do not accidentally revert this.

## Testing steps

1. `go build ./cmd/server/...` — should compile cleanly.
2. `go test ./...` — existing tests should pass.
3. Send a CORS preflight to `gotak.app` from a non-listed origin. Verify the response contains `Access-Control-Allow-Origin: *` and **no** `Access-Control-Allow-Credentials` header.
4. Confirm the JWT-authenticated game routes still work from the intended frontend (JWT is sent via `Authorization` header, not a cookie).

## Audit note

**Reviewed:** `cmd/server/main.go`, `cmd/server/auth_pkgz.go`, `cmd/server/database.go`, `go.mod`, `Dockerfile`.

**Other findings (not fixed here, low priority):**
- The `rootHandler` builds HTML via `fmt.Sprintf` using content from `docs.GetSwaggerSpec()`. If the swagger spec is generated from code, this is safe; worth confirming.
- `cmd/server/main.go` missing `ReadHeaderTimeout` (only `ReadTimeout` and `WriteTimeout` are set). The existing 15 s `ReadTimeout` covers the most critical case.
- Dependencies appear current (`go 1.25.0`, all modules at recent versions).

**No existing `audit/` PR on this repo before this one.**
