### PR TITLE
feat: parse TPS and use it in TestFindRoad

### DIFF
--- a/board_test.go
+++ b/board_test.go
@@ -171,7 +171,107 @@ func TestIsEdge(t *testing.T) {
 }
 
 func TestFindRoad(t *testing.T) {
-	// TODO(#39): Write a test using TPS
+	cases := []struct {
+		name       string
+		tps        string
+		startEdges []string
+		endEdges   []string
+		player     int
+		expectRoad bool
+	}{
+		{
+			name:       "horizontal-white-road",
+			tps:        "x5/x5/x5/x5/1,1,1,1,1 1 1",
+			startEdges: []string{"a1"},
+			endEdges:   []string{"e1"},
+			player:     PlayerWhite,
+			expectRoad: true,
+		},
+		{
+			name:       "vertical-black-road",
+			tps:        "2,x4/2,x4/2,x4/2,x4/2,x4 1 1",
+			startEdges: []string{"a1"},
+			endEdges:   []string{"a5"},
+			player:     PlayerBlack,
+			expectRoad: true,
+		},
+		{
+			name:       "broken-road-with-standing",
+			tps:        "x5/x5/x5/x5/1,1,1S,1,1 1 1",
+			startEdges: []string{"a1"},
+			endEdges:   []string{"e1"},
+			player:     PlayerWhite,
+			expectRoad: false,
+		},
+		{
+			name:       "capstone-completes-road",
+			tps:        "x5/x5/x5/x5/1,1,1C,1,1 1 1",
+			startEdges: []string{"a1"},
+			endEdges:   []string{"e1"},
+			player:     PlayerWhite,
+			expectRoad: true,
+		},
+		{
+			name:       "stack-with-opponent-on-top-blocks-road",
+			tps:        "x5/x5/x5/x5/1,1,12,1,1 1 1",
+			startEdges: []string{"a1"},
+			endEdges:   []string{"e1"},
+			player:     PlayerWhite,
+			expectRoad: false,
+		},
+		{
+			name:       "L-shaped-road",
+			tps:        "x5/x5/x5/1,1,1,1,1/1,x4 1 1",
+			startEdges: []string{"a1"},
+			endEdges:   []string{"e2"},
+			player:     PlayerWhite,
+			expectRoad: true,
+		},
+		{
+			name:       "no-stones-no-road",
+			tps:        "x5/x5/x5/x5/x5 1 1",
+			startEdges: []string{"a1"},
+			endEdges:   []string{"e1"},
+			player:     PlayerWhite,
+			expectRoad: false,
+		},
+		{
+			name:       "isolated-stones-do-not-connect",
+			tps:        "x5/x5/x5/x5/1,x3,1 1 1",
+			startEdges: []string{"a1"},
+			endEdges:   []string{"e1"},
+			player:     PlayerWhite,
+			expectRoad: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, _, _, err := ParseTPS(tc.tps)
+			if err != nil {
+				t.Fatalf("parse tps: %v", err)
+			}
+
+			found := false
+			for _, start := range tc.startEdges {
+				if b.Color(start) != tc.player {
+					continue
+				}
+				top := b.TopStone(start)
+				if top == nil || top.Type == StoneStanding {
+					continue
+				}
+				if b.FindRoad(start, tc.endEdges) {
+					found = true
+					break
+				}
+			}
+
+			if found != tc.expectRoad {
+				t.Errorf("FindRoad from %v to %v: got %v, want %v", tc.startEdges, tc.endEdges, found, tc.expectRoad)
+			}
+		})
+	}
 }
 
 func TestValidSquareIntegerOverflowPrevention(t *testing.T) {

--- a/cmd/server/docs/swagger.json
+++ b/cmd/server/docs/swagger.json
@@ -1,959 +1,959 @@
 {
-    "swagger": "2.0",
-    "info": {
-        "description": "A Tak game server API with authentication",
-        "title": "GoTak API",
-        "contact": {
-            "name": "API Support",
-            "url": "http://github.com/icco/gotak"
-        },
-        "license": {
-            "name": "MIT",
-            "url": "https://github.com/icco/gotak/blob/main/LICENSE"
-        },
-        "version": "1.0"
+  "swagger": "2.0",
+  "info": {
+    "description": "A Tak game server API with authentication",
+    "title": "GoTak API",
+    "contact": {
+      "name": "API Support",
+      "url": "http://github.com/icco/gotak"
     },
-    "host": "gotak.app",
-    "basePath": "/",
-    "paths": {
-        "/": {
-            "get": {
-                "description": "Returns basic API information and available endpoints",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "text/html"
-                ],
-                "tags": [
-                    "info"
-                ],
-                "summary": "Get API information",
-                "responses": {
-                    "200": {
-                        "description": "HTML page with API information",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/auth/confirm-reset": {
-            "post": {
-                "description": "Reset password with token",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "auth"
-                ],
-                "summary": "Confirm password reset",
-                "parameters": [
-                    {
-                        "description": "Confirm reset request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/main.ConfirmResetRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/main.MessageResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/auth/login": {
-            "post": {
-                "description": "Login with email and password",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "auth"
-                ],
-                "summary": "Login user",
-                "parameters": [
-                    {
-                        "description": "User login data",
-                        "name": "user",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/main.LoginRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/main.AuthResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/auth/logout": {
-            "post": {
-                "description": "Logout current user (client should discard token)",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "auth"
-                ],
-                "summary": "Logout user",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/main.MessageResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/auth/profile": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get current user profile information",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "auth"
-                ],
-                "summary": "Get user profile",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/main.User"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            },
-            "put": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Update current user profile information",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "auth"
-                ],
-                "summary": "Update user profile",
-                "parameters": [
-                    {
-                        "description": "Profile update data",
-                        "name": "profile",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/main.UpdateProfileRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/main.User"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/auth/register": {
-            "post": {
-                "description": "Register with email and password",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "auth"
-                ],
-                "summary": "Register a new user",
-                "parameters": [
-                    {
-                        "description": "User registration data",
-                        "name": "user",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/main.RegisterRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/main.MessageResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/auth/reset-password": {
-            "post": {
-                "description": "Send password reset token for email",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "auth"
-                ],
-                "summary": "Request password reset",
-                "parameters": [
-                    {
-                        "description": "Reset password request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/main.ResetPasswordRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/main.MessageResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/game/new": {
-            "get": {
-                "description": "Creates a new Tak game with the specified board size",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "game"
-                ],
-                "summary": "Create a new game",
-                "parameters": [
-                    {
-                        "description": "Game configuration",
-                        "name": "game",
-                        "in": "body",
-                        "schema": {
-                            "$ref": "#/definitions/main.CreateGameRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "307": {
-                        "description": "Redirect to game URL",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "description": "Creates a new Tak game with the specified board size",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "game"
-                ],
-                "summary": "Create a new game",
-                "parameters": [
-                    {
-                        "description": "Game configuration",
-                        "name": "game",
-                        "in": "body",
-                        "schema": {
-                            "$ref": "#/definitions/main.CreateGameRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "307": {
-                        "description": "Redirect to game URL",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/game/{slug}": {
-            "get": {
-                "description": "Returns the current state of a game",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "game"
-                ],
-                "summary": "Get game state",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Game slug identifier",
-                        "name": "slug",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/gotak.Game"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/game/{slug}/join": {
-            "post": {
-                "description": "Join a game that is waiting for a second player (as black player)",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "game"
-                ],
-                "summary": "Join a waiting game",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Game slug identifier",
-                        "name": "slug",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/main.MessageResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/game/{slug}/move": {
-            "post": {
-                "description": "Submit a move for a specific game",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "game"
-                ],
-                "summary": "Make a move in a game",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Game slug identifier",
-                        "name": "slug",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Move details",
-                        "name": "move",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/main.MoveRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/gotak.Game"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/game/{slug}/{turn}": {
-            "get": {
-                "description": "Returns the state of a game at a specific turn",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "game"
-                ],
-                "summary": "Get specific turn",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Game slug identifier",
-                        "name": "slug",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Turn number",
-                        "name": "turn",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/gotak.Turn"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/healthz": {
-            "get": {
-                "description": "Returns service health status",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "health"
-                ],
-                "summary": "Health check",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/main.HealthResponse"
-                        }
-                    }
-                }
-            }
-        }
+    "license": {
+      "name": "MIT",
+      "url": "https://github.com/icco/gotak/blob/main/LICENSE"
     },
-    "definitions": {
-        "gotak.Board": {
-            "type": "object",
-            "properties": {
-                "size": {
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "squares": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/definitions/gotak.Stone"
-                        }
-                    }
-                }
+    "version": "1.0"
+  },
+  "host": "gotak.app",
+  "basePath": "/",
+  "paths": {
+    "/": {
+      "get": {
+        "description": "Returns basic API information and available endpoints",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "text/html"
+        ],
+        "tags": [
+          "info"
+        ],
+        "summary": "Get API information",
+        "responses": {
+          "200": {
+            "description": "HTML page with API information",
+            "schema": {
+              "type": "string"
             }
-        },
-        "gotak.Game": {
-            "type": "object",
-            "properties": {
-                "board": {
-                    "$ref": "#/definitions/gotak.Board"
-                },
-                "id": {
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "meta": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/gotak.Tag"
-                    }
-                },
-                "slug": {
-                    "type": "string"
-                },
-                "turns": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/gotak.Turn"
-                    }
-                }
-            }
-        },
-        "gotak.Move": {
-            "type": "object",
-            "properties": {
-                "moveCount": {
-                    "description": "Move only",
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "moveDirection": {
-                    "type": "string"
-                },
-                "moveDropCounts": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer",
-                        "format": "int64"
-                    }
-                },
-                "square": {
-                    "type": "string"
-                },
-                "stone": {
-                    "description": "Both Drop and Move",
-                    "type": "string"
-                },
-                "text": {
-                    "type": "string"
-                }
-            }
-        },
-        "gotak.Stone": {
-            "type": "object",
-            "properties": {
-                "player": {
-                    "type": "integer"
-                },
-                "type": {
-                    "type": "string"
-                }
-            }
-        },
-        "gotak.Tag": {
-            "type": "object",
-            "properties": {
-                "key": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
-        "gotak.Turn": {
-            "type": "object",
-            "properties": {
-                "comment": {
-                    "type": "string"
-                },
-                "first": {
-                    "$ref": "#/definitions/gotak.Move"
-                },
-                "number": {
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "result": {
-                    "type": "string"
-                },
-                "second": {
-                    "$ref": "#/definitions/gotak.Move"
-                }
-            }
-        },
-        "main.AuthResponse": {
-            "type": "object",
-            "properties": {
-                "token": {
-                    "type": "string"
-                },
-                "user": {
-                    "$ref": "#/definitions/main.User"
-                }
-            }
-        },
-        "main.ConfirmResetRequest": {
-            "type": "object",
-            "properties": {
-                "new_password": {
-                    "type": "string",
-                    "example": "newsecretpassword"
-                },
-                "token": {
-                    "type": "string",
-                    "example": "reset-token-here"
-                }
-            }
-        },
-        "main.CreateGameRequest": {
-            "type": "object",
-            "properties": {
-                "size": {
-                    "type": "string",
-                    "example": "8"
-                }
-            }
-        },
-        "main.ErrorResponse": {
-            "type": "object",
-            "properties": {
-                "error": {
-                    "type": "string",
-                    "example": "Something went wrong"
-                }
-            }
-        },
-        "main.HealthResponse": {
-            "type": "object",
-            "properties": {
-                "branch": {
-                    "type": "string",
-                    "example": "main"
-                },
-                "healthy": {
-                    "type": "string",
-                    "example": "true"
-                },
-                "revision": {
-                    "type": "string",
-                    "example": "abc123def"
-                },
-                "tag": {
-                    "type": "string",
-                    "example": "v1.0.0"
-                }
-            }
-        },
-        "main.LoginRequest": {
-            "type": "object",
-            "properties": {
-                "email": {
-                    "type": "string",
-                    "example": "user@example.com"
-                },
-                "password": {
-                    "type": "string",
-                    "example": "secretpassword"
-                }
-            }
-        },
-        "main.MessageResponse": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string",
-                    "example": "Operation successful"
-                }
-            }
-        },
-        "main.MoveRequest": {
-            "type": "object",
-            "properties": {
-                "move": {
-                    "type": "string",
-                    "example": "c3"
-                },
-                "player": {
-                    "type": "integer",
-                    "example": 1
-                },
-                "turn": {
-                    "type": "integer",
-                    "example": 1
-                }
-            }
-        },
-        "main.RegisterRequest": {
-            "type": "object",
-            "properties": {
-                "email": {
-                    "type": "string",
-                    "example": "user@example.com"
-                },
-                "name": {
-                    "type": "string",
-                    "example": "John Doe"
-                },
-                "password": {
-                    "type": "string",
-                    "example": "secretpassword"
-                }
-            }
-        },
-        "main.ResetPasswordRequest": {
-            "type": "object",
-            "properties": {
-                "email": {
-                    "type": "string",
-                    "example": "user@example.com"
-                }
-            }
-        },
-        "main.UpdateProfileRequest": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "preferences": {
-                    "type": "string"
-                }
-            }
-        },
-        "main.User": {
-            "type": "object",
-            "properties": {
-                "avatar_url": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "email": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "preferences": {
-                    "type": "string"
-                },
-                "provider": {
-                    "type": "string"
-                },
-                "provider_id": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
+          }
         }
+      }
     },
-    "securityDefinitions": {
-        "BearerAuth": {
-            "description": "JWT token in format: Bearer {token}",
-            "type": "apiKey",
-            "name": "Authorization",
-            "in": "header"
+    "/auth/confirm-reset": {
+      "post": {
+        "description": "Reset password with token",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "auth"
+        ],
+        "summary": "Confirm password reset",
+        "parameters": [
+          {
+            "description": "Confirm reset request",
+            "name": "request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/main.ConfirmResetRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/main.MessageResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
         }
+      }
+    },
+    "/auth/login": {
+      "post": {
+        "description": "Login with email and password",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "auth"
+        ],
+        "summary": "Login user",
+        "parameters": [
+          {
+            "description": "User login data",
+            "name": "user",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/main.LoginRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/main.AuthResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/auth/logout": {
+      "post": {
+        "description": "Logout current user (client should discard token)",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "auth"
+        ],
+        "summary": "Logout user",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/main.MessageResponse"
+            }
+          }
+        }
+      }
+    },
+    "/auth/profile": {
+      "get": {
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "description": "Get current user profile information",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "auth"
+        ],
+        "summary": "Get user profile",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/main.User"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "description": "Update current user profile information",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "auth"
+        ],
+        "summary": "Update user profile",
+        "parameters": [
+          {
+            "description": "Profile update data",
+            "name": "profile",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/main.UpdateProfileRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/main.User"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/auth/register": {
+      "post": {
+        "description": "Register with email and password",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "auth"
+        ],
+        "summary": "Register a new user",
+        "parameters": [
+          {
+            "description": "User registration data",
+            "name": "user",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/main.RegisterRequest"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/main.MessageResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/auth/reset-password": {
+      "post": {
+        "description": "Send password reset token for email",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "auth"
+        ],
+        "summary": "Request password reset",
+        "parameters": [
+          {
+            "description": "Reset password request",
+            "name": "request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/main.ResetPasswordRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/main.MessageResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/game/new": {
+      "get": {
+        "description": "Creates a new Tak game with the specified board size",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "game"
+        ],
+        "summary": "Create a new game",
+        "parameters": [
+          {
+            "description": "Game configuration",
+            "name": "game",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/main.CreateGameRequest"
+            }
+          }
+        ],
+        "responses": {
+          "307": {
+            "description": "Redirect to game URL",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a new Tak game with the specified board size",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "game"
+        ],
+        "summary": "Create a new game",
+        "parameters": [
+          {
+            "description": "Game configuration",
+            "name": "game",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/main.CreateGameRequest"
+            }
+          }
+        ],
+        "responses": {
+          "307": {
+            "description": "Redirect to game URL",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/game/{slug}": {
+      "get": {
+        "description": "Returns the current state of a game",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "game"
+        ],
+        "summary": "Get game state",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Game slug identifier",
+            "name": "slug",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/gotak.Game"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/game/{slug}/join": {
+      "post": {
+        "description": "Join a game that is waiting for a second player (as black player)",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "game"
+        ],
+        "summary": "Join a waiting game",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Game slug identifier",
+            "name": "slug",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/main.MessageResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/game/{slug}/move": {
+      "post": {
+        "description": "Submit a move for a specific game",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "game"
+        ],
+        "summary": "Make a move in a game",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Game slug identifier",
+            "name": "slug",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "Move details",
+            "name": "move",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/main.MoveRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/gotak.Game"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/game/{slug}/{turn}": {
+      "get": {
+        "description": "Returns the state of a game at a specific turn",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "game"
+        ],
+        "summary": "Get specific turn",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Game slug identifier",
+            "name": "slug",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "integer",
+            "description": "Turn number",
+            "name": "turn",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/gotak.Turn"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/healthz": {
+      "get": {
+        "description": "Returns service health status",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "health"
+        ],
+        "summary": "Health check",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/main.HealthResponse"
+            }
+          }
+        }
+      }
     }
+  },
+  "definitions": {
+    "gotak.Board": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "squares": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/gotak.Stone"
+            }
+          }
+        }
+      }
+    },
+    "gotak.Game": {
+      "type": "object",
+      "properties": {
+        "board": {
+          "$ref": "#/definitions/gotak.Board"
+        },
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "meta": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/gotak.Tag"
+          }
+        },
+        "slug": {
+          "type": "string"
+        },
+        "turns": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/gotak.Turn"
+          }
+        }
+      }
+    },
+    "gotak.Move": {
+      "type": "object",
+      "properties": {
+        "moveCount": {
+          "description": "Move only",
+          "type": "integer",
+          "format": "int64"
+        },
+        "moveDirection": {
+          "type": "string"
+        },
+        "moveDropCounts": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "square": {
+          "type": "string"
+        },
+        "stone": {
+          "description": "Both Drop and Move",
+          "type": "string"
+        },
+        "text": {
+          "type": "string"
+        }
+      }
+    },
+    "gotak.Stone": {
+      "type": "object",
+      "properties": {
+        "player": {
+          "type": "integer"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "gotak.Tag": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "gotak.Turn": {
+      "type": "object",
+      "properties": {
+        "comment": {
+          "type": "string"
+        },
+        "first": {
+          "$ref": "#/definitions/gotak.Move"
+        },
+        "number": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "result": {
+          "type": "string"
+        },
+        "second": {
+          "$ref": "#/definitions/gotak.Move"
+        }
+      }
+    },
+    "main.AuthResponse": {
+      "type": "object",
+      "properties": {
+        "token": {
+          "type": "string"
+        },
+        "user": {
+          "$ref": "#/definitions/main.User"
+        }
+      }
+    },
+    "main.ConfirmResetRequest": {
+      "type": "object",
+      "properties": {
+        "new_password": {
+          "type": "string",
+          "example": "newsecretpassword"
+        },
+        "token": {
+          "type": "string",
+          "example": "reset-token-here"
+        }
+      }
+    },
+    "main.CreateGameRequest": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "string",
+          "example": "8"
+        }
+      }
+    },
+    "main.ErrorResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "string",
+          "example": "Something went wrong"
+        }
+      }
+    },
+    "main.HealthResponse": {
+      "type": "object",
+      "properties": {
+        "branch": {
+          "type": "string",
+          "example": "main"
+        },
+        "healthy": {
+          "type": "string",
+          "example": "true"
+        },
+        "revision": {
+          "type": "string",
+          "example": "abc123def"
+        },
+        "tag": {
+          "type": "string",
+          "example": "v1.0.0"
+        }
+      }
+    },
+    "main.LoginRequest": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "example": "user@example.com"
+        },
+        "password": {
+          "type": "string",
+          "example": "secretpassword"
+        }
+      }
+    },
+    "main.MessageResponse": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string",
+          "example": "Operation successful"
+        }
+      }
+    },
+    "main.MoveRequest": {
+      "type": "object",
+      "properties": {
+        "move": {
+          "type": "string",
+          "example": "c3"
+        },
+        "player": {
+          "type": "integer",
+          "example": 1
+        },
+        "turn": {
+          "type": "integer",
+          "example": 1
+        }
+      }
+    },
+    "main.RegisterRequest": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "example": "user@example.com"
+        },
+        "name": {
+          "type": "string",
+          "example": "John Doe"
+        },
+        "password": {
+          "type": "string",
+          "example": "secretpassword"
+        }
+      }
+    },
+    "main.ResetPasswordRequest": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "example": "user@example.com"
+        }
+      }
+    },
+    "main.UpdateProfileRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "preferences": {
+          "type": "string"
+        }
+      }
+    },
+    "main.User": {
+      "type": "object",
+      "properties": {
+        "avatar_url": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "preferences": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "provider_id": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "securityDefinitions": {
+    "BearerAuth": {
+      "description": "JWT token in format: Bearer {token}",
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header"
+    }
+  }
 }

--- a/cmd/server/docs/swagger.json
+++ b/cmd/server/docs/swagger.json
@@ -1,963 +1,963 @@
 {
-    "swagger": "2.0",
-    "info": {
-        "description": "A Tak game server API with authentication",
-        "title": "GoTak API",
-        "contact": {
-            "name": "API Support",
-            "url": "http://github.com/icco/gotak"
-        },
-        "license": {
-            "name": "MIT",
-            "url": "https://github.com/icco/gotak/blob/main/LICENSE"
-        },
-        "version": "1.0"
+  "swagger": "2.0",
+  "info": {
+    "description": "A Tak game server API with authentication",
+    "title": "GoTak API",
+    "contact": {
+      "name": "API Support",
+      "url": "http://github.com/icco/gotak"
     },
-    "host": "gotak.app",
-    "basePath": "/",
-    "paths": {
-        "/": {
-            "get": {
-                "description": "Returns basic API information and available endpoints",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "text/html"
-                ],
-                "tags": [
-                    "info"
-                ],
-                "summary": "Get API information",
-                "responses": {
-                    "200": {
-                        "description": "HTML page with API information",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/auth/confirm-reset": {
-            "post": {
-                "description": "Reset password with token",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "auth"
-                ],
-                "summary": "Confirm password reset",
-                "parameters": [
-                    {
-                        "description": "Confirm reset request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/main.ConfirmResetRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/main.MessageResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/auth/login": {
-            "post": {
-                "description": "Login with email and password",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "auth"
-                ],
-                "summary": "Login user",
-                "parameters": [
-                    {
-                        "description": "User login data",
-                        "name": "user",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/main.LoginRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/main.AuthResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/auth/logout": {
-            "post": {
-                "description": "Logout current user (client should discard token)",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "auth"
-                ],
-                "summary": "Logout user",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/main.MessageResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/auth/profile": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get current user profile information",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "auth"
-                ],
-                "summary": "Get user profile",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/main.User"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            },
-            "put": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Update current user profile information",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "auth"
-                ],
-                "summary": "Update user profile",
-                "parameters": [
-                    {
-                        "description": "Profile update data",
-                        "name": "profile",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/main.UpdateProfileRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/main.User"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/auth/register": {
-            "post": {
-                "description": "Register with email and password",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "auth"
-                ],
-                "summary": "Register a new user",
-                "parameters": [
-                    {
-                        "description": "User registration data",
-                        "name": "user",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/main.RegisterRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/main.MessageResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/auth/reset-password": {
-            "post": {
-                "description": "Send password reset token for email",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "auth"
-                ],
-                "summary": "Request password reset",
-                "parameters": [
-                    {
-                        "description": "Reset password request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/main.ResetPasswordRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/main.MessageResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/game/new": {
-            "get": {
-                "description": "Creates a new Tak game with the specified board size",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "game"
-                ],
-                "summary": "Create a new game",
-                "parameters": [
-                    {
-                        "description": "Game configuration",
-                        "name": "game",
-                        "in": "body",
-                        "schema": {
-                            "$ref": "#/definitions/main.CreateGameRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "307": {
-                        "description": "Redirect to game URL",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "description": "Creates a new Tak game with the specified board size",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "game"
-                ],
-                "summary": "Create a new game",
-                "parameters": [
-                    {
-                        "description": "Game configuration",
-                        "name": "game",
-                        "in": "body",
-                        "schema": {
-                            "$ref": "#/definitions/main.CreateGameRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "307": {
-                        "description": "Redirect to game URL",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/game/{slug}": {
-            "get": {
-                "description": "Returns the current state of a game",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "game"
-                ],
-                "summary": "Get game state",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Game slug identifier",
-                        "name": "slug",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/gotak.Game"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/game/{slug}/join": {
-            "post": {
-                "description": "Join a game that is waiting for a second player (as black player)",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "game"
-                ],
-                "summary": "Join a waiting game",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Game slug identifier",
-                        "name": "slug",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/main.MessageResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/game/{slug}/move": {
-            "post": {
-                "description": "Submit a move for a specific game",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "game"
-                ],
-                "summary": "Make a move in a game",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Game slug identifier",
-                        "name": "slug",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Move details",
-                        "name": "move",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/main.MoveRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/gotak.Game"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/game/{slug}/{turn}": {
-            "get": {
-                "description": "Returns the state of a game at a specific turn",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "game"
-                ],
-                "summary": "Get specific turn",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Game slug identifier",
-                        "name": "slug",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Turn number",
-                        "name": "turn",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/gotak.Turn"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/healthz": {
-            "get": {
-                "description": "Returns service health status",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "health"
-                ],
-                "summary": "Health check",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/main.HealthResponse"
-                        }
-                    }
-                }
-            }
-        }
+    "license": {
+      "name": "MIT",
+      "url": "https://github.com/icco/gotak/blob/main/LICENSE"
     },
-    "definitions": {
-        "gotak.Board": {
-            "type": "object",
-            "properties": {
-                "size": {
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "squares": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/definitions/gotak.Stone"
-                        }
-                    }
-                }
+    "version": "1.0"
+  },
+  "host": "gotak.app",
+  "basePath": "/",
+  "paths": {
+    "/": {
+      "get": {
+        "description": "Returns basic API information and available endpoints",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "text/html"
+        ],
+        "tags": [
+          "info"
+        ],
+        "summary": "Get API information",
+        "responses": {
+          "200": {
+            "description": "HTML page with API information",
+            "schema": {
+              "type": "string"
             }
-        },
-        "gotak.Game": {
-            "type": "object",
-            "properties": {
-                "board": {
-                    "$ref": "#/definitions/gotak.Board"
-                },
-                "id": {
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "meta": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/gotak.Tag"
-                    }
-                },
-                "slug": {
-                    "type": "string"
-                },
-                "turns": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/gotak.Turn"
-                    }
-                }
-            }
-        },
-        "gotak.Move": {
-            "type": "object",
-            "properties": {
-                "moveCount": {
-                    "description": "Move only",
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "moveDirection": {
-                    "type": "string"
-                },
-                "moveDropCounts": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer",
-                        "format": "int64"
-                    }
-                },
-                "square": {
-                    "type": "string"
-                },
-                "stone": {
-                    "description": "Both Drop and Move",
-                    "type": "string"
-                },
-                "text": {
-                    "type": "string"
-                }
-            }
-        },
-        "gotak.Stone": {
-            "type": "object",
-            "properties": {
-                "player": {
-                    "type": "integer"
-                },
-                "type": {
-                    "type": "string"
-                }
-            }
-        },
-        "gotak.Tag": {
-            "type": "object",
-            "properties": {
-                "key": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
-        "gotak.Turn": {
-            "type": "object",
-            "properties": {
-                "branch": {
-                    "description": "Branch is the optional PTN branch label appended to the turn\nnumber (e.g. `1a.` -\u003e \"a\"). Main-line turns leave it empty.",
-                    "type": "string"
-                },
-                "comment": {
-                    "type": "string"
-                },
-                "first": {
-                    "$ref": "#/definitions/gotak.Move"
-                },
-                "number": {
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "result": {
-                    "type": "string"
-                },
-                "second": {
-                    "$ref": "#/definitions/gotak.Move"
-                }
-            }
-        },
-        "main.AuthResponse": {
-            "type": "object",
-            "properties": {
-                "token": {
-                    "type": "string"
-                },
-                "user": {
-                    "$ref": "#/definitions/main.User"
-                }
-            }
-        },
-        "main.ConfirmResetRequest": {
-            "type": "object",
-            "properties": {
-                "new_password": {
-                    "type": "string",
-                    "example": "newsecretpassword"
-                },
-                "token": {
-                    "type": "string",
-                    "example": "reset-token-here"
-                }
-            }
-        },
-        "main.CreateGameRequest": {
-            "type": "object",
-            "properties": {
-                "size": {
-                    "type": "string",
-                    "example": "8"
-                }
-            }
-        },
-        "main.ErrorResponse": {
-            "type": "object",
-            "properties": {
-                "error": {
-                    "type": "string",
-                    "example": "Something went wrong"
-                }
-            }
-        },
-        "main.HealthResponse": {
-            "type": "object",
-            "properties": {
-                "branch": {
-                    "type": "string",
-                    "example": "main"
-                },
-                "healthy": {
-                    "type": "string",
-                    "example": "true"
-                },
-                "revision": {
-                    "type": "string",
-                    "example": "abc123def"
-                },
-                "tag": {
-                    "type": "string",
-                    "example": "v1.0.0"
-                }
-            }
-        },
-        "main.LoginRequest": {
-            "type": "object",
-            "properties": {
-                "email": {
-                    "type": "string",
-                    "example": "user@example.com"
-                },
-                "password": {
-                    "type": "string",
-                    "example": "secretpassword"
-                }
-            }
-        },
-        "main.MessageResponse": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string",
-                    "example": "Operation successful"
-                }
-            }
-        },
-        "main.MoveRequest": {
-            "type": "object",
-            "properties": {
-                "move": {
-                    "type": "string",
-                    "example": "c3"
-                },
-                "player": {
-                    "type": "integer",
-                    "example": 1
-                },
-                "turn": {
-                    "type": "integer",
-                    "example": 1
-                }
-            }
-        },
-        "main.RegisterRequest": {
-            "type": "object",
-            "properties": {
-                "email": {
-                    "type": "string",
-                    "example": "user@example.com"
-                },
-                "name": {
-                    "type": "string",
-                    "example": "John Doe"
-                },
-                "password": {
-                    "type": "string",
-                    "example": "secretpassword"
-                }
-            }
-        },
-        "main.ResetPasswordRequest": {
-            "type": "object",
-            "properties": {
-                "email": {
-                    "type": "string",
-                    "example": "user@example.com"
-                }
-            }
-        },
-        "main.UpdateProfileRequest": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "preferences": {
-                    "type": "string"
-                }
-            }
-        },
-        "main.User": {
-            "type": "object",
-            "properties": {
-                "avatar_url": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "email": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "preferences": {
-                    "type": "string"
-                },
-                "provider": {
-                    "type": "string"
-                },
-                "provider_id": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
+          }
         }
+      }
     },
-    "securityDefinitions": {
-        "BearerAuth": {
-            "description": "JWT token in format: Bearer {token}",
-            "type": "apiKey",
-            "name": "Authorization",
-            "in": "header"
+    "/auth/confirm-reset": {
+      "post": {
+        "description": "Reset password with token",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "auth"
+        ],
+        "summary": "Confirm password reset",
+        "parameters": [
+          {
+            "description": "Confirm reset request",
+            "name": "request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/main.ConfirmResetRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/main.MessageResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
         }
+      }
+    },
+    "/auth/login": {
+      "post": {
+        "description": "Login with email and password",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "auth"
+        ],
+        "summary": "Login user",
+        "parameters": [
+          {
+            "description": "User login data",
+            "name": "user",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/main.LoginRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/main.AuthResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/auth/logout": {
+      "post": {
+        "description": "Logout current user (client should discard token)",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "auth"
+        ],
+        "summary": "Logout user",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/main.MessageResponse"
+            }
+          }
+        }
+      }
+    },
+    "/auth/profile": {
+      "get": {
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "description": "Get current user profile information",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "auth"
+        ],
+        "summary": "Get user profile",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/main.User"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "description": "Update current user profile information",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "auth"
+        ],
+        "summary": "Update user profile",
+        "parameters": [
+          {
+            "description": "Profile update data",
+            "name": "profile",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/main.UpdateProfileRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/main.User"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/auth/register": {
+      "post": {
+        "description": "Register with email and password",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "auth"
+        ],
+        "summary": "Register a new user",
+        "parameters": [
+          {
+            "description": "User registration data",
+            "name": "user",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/main.RegisterRequest"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/main.MessageResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/auth/reset-password": {
+      "post": {
+        "description": "Send password reset token for email",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "auth"
+        ],
+        "summary": "Request password reset",
+        "parameters": [
+          {
+            "description": "Reset password request",
+            "name": "request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/main.ResetPasswordRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/main.MessageResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/game/new": {
+      "get": {
+        "description": "Creates a new Tak game with the specified board size",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "game"
+        ],
+        "summary": "Create a new game",
+        "parameters": [
+          {
+            "description": "Game configuration",
+            "name": "game",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/main.CreateGameRequest"
+            }
+          }
+        ],
+        "responses": {
+          "307": {
+            "description": "Redirect to game URL",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a new Tak game with the specified board size",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "game"
+        ],
+        "summary": "Create a new game",
+        "parameters": [
+          {
+            "description": "Game configuration",
+            "name": "game",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/main.CreateGameRequest"
+            }
+          }
+        ],
+        "responses": {
+          "307": {
+            "description": "Redirect to game URL",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/game/{slug}": {
+      "get": {
+        "description": "Returns the current state of a game",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "game"
+        ],
+        "summary": "Get game state",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Game slug identifier",
+            "name": "slug",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/gotak.Game"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/game/{slug}/join": {
+      "post": {
+        "description": "Join a game that is waiting for a second player (as black player)",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "game"
+        ],
+        "summary": "Join a waiting game",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Game slug identifier",
+            "name": "slug",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/main.MessageResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/game/{slug}/move": {
+      "post": {
+        "description": "Submit a move for a specific game",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "game"
+        ],
+        "summary": "Make a move in a game",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Game slug identifier",
+            "name": "slug",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "Move details",
+            "name": "move",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/main.MoveRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/gotak.Game"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/game/{slug}/{turn}": {
+      "get": {
+        "description": "Returns the state of a game at a specific turn",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "game"
+        ],
+        "summary": "Get specific turn",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Game slug identifier",
+            "name": "slug",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "integer",
+            "description": "Turn number",
+            "name": "turn",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/gotak.Turn"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/healthz": {
+      "get": {
+        "description": "Returns service health status",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "health"
+        ],
+        "summary": "Health check",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/main.HealthResponse"
+            }
+          }
+        }
+      }
     }
+  },
+  "definitions": {
+    "gotak.Board": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "squares": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/gotak.Stone"
+            }
+          }
+        }
+      }
+    },
+    "gotak.Game": {
+      "type": "object",
+      "properties": {
+        "board": {
+          "$ref": "#/definitions/gotak.Board"
+        },
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "meta": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/gotak.Tag"
+          }
+        },
+        "slug": {
+          "type": "string"
+        },
+        "turns": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/gotak.Turn"
+          }
+        }
+      }
+    },
+    "gotak.Move": {
+      "type": "object",
+      "properties": {
+        "moveCount": {
+          "description": "Move only",
+          "type": "integer",
+          "format": "int64"
+        },
+        "moveDirection": {
+          "type": "string"
+        },
+        "moveDropCounts": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "square": {
+          "type": "string"
+        },
+        "stone": {
+          "description": "Both Drop and Move",
+          "type": "string"
+        },
+        "text": {
+          "type": "string"
+        }
+      }
+    },
+    "gotak.Stone": {
+      "type": "object",
+      "properties": {
+        "player": {
+          "type": "integer"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "gotak.Tag": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "gotak.Turn": {
+      "type": "object",
+      "properties": {
+        "branch": {
+          "description": "Branch is the optional PTN branch label appended to the turn\nnumber (e.g. `1a.` -> \"a\"). Main-line turns leave it empty.",
+          "type": "string"
+        },
+        "comment": {
+          "type": "string"
+        },
+        "first": {
+          "$ref": "#/definitions/gotak.Move"
+        },
+        "number": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "result": {
+          "type": "string"
+        },
+        "second": {
+          "$ref": "#/definitions/gotak.Move"
+        }
+      }
+    },
+    "main.AuthResponse": {
+      "type": "object",
+      "properties": {
+        "token": {
+          "type": "string"
+        },
+        "user": {
+          "$ref": "#/definitions/main.User"
+        }
+      }
+    },
+    "main.ConfirmResetRequest": {
+      "type": "object",
+      "properties": {
+        "new_password": {
+          "type": "string",
+          "example": "newsecretpassword"
+        },
+        "token": {
+          "type": "string",
+          "example": "reset-token-here"
+        }
+      }
+    },
+    "main.CreateGameRequest": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "string",
+          "example": "8"
+        }
+      }
+    },
+    "main.ErrorResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "string",
+          "example": "Something went wrong"
+        }
+      }
+    },
+    "main.HealthResponse": {
+      "type": "object",
+      "properties": {
+        "branch": {
+          "type": "string",
+          "example": "main"
+        },
+        "healthy": {
+          "type": "string",
+          "example": "true"
+        },
+        "revision": {
+          "type": "string",
+          "example": "abc123def"
+        },
+        "tag": {
+          "type": "string",
+          "example": "v1.0.0"
+        }
+      }
+    },
+    "main.LoginRequest": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "example": "user@example.com"
+        },
+        "password": {
+          "type": "string",
+          "example": "secretpassword"
+        }
+      }
+    },
+    "main.MessageResponse": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string",
+          "example": "Operation successful"
+        }
+      }
+    },
+    "main.MoveRequest": {
+      "type": "object",
+      "properties": {
+        "move": {
+          "type": "string",
+          "example": "c3"
+        },
+        "player": {
+          "type": "integer",
+          "example": 1
+        },
+        "turn": {
+          "type": "integer",
+          "example": 1
+        }
+      }
+    },
+    "main.RegisterRequest": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "example": "user@example.com"
+        },
+        "name": {
+          "type": "string",
+          "example": "John Doe"
+        },
+        "password": {
+          "type": "string",
+          "example": "secretpassword"
+        }
+      }
+    },
+    "main.ResetPasswordRequest": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "example": "user@example.com"
+        }
+      }
+    },
+    "main.UpdateProfileRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "preferences": {
+          "type": "string"
+        }
+      }
+    },
+    "main.User": {
+      "type": "object",
+      "properties": {
+        "avatar_url": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "preferences": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "provider_id": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "securityDefinitions": {
+    "BearerAuth": {
+      "description": "JWT token in format: Bearer {token}",
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header"
+    }
+  }
 }

--- a/cmd/server/docs/swagger.yaml
+++ b/cmd/server/docs/swagger.yaml
@@ -210,10 +210,10 @@ paths:
   /:
     get:
       consumes:
-      - application/json
+        - application/json
       description: Returns basic API information and available endpoints
       produces:
-      - text/html
+        - text/html
       responses:
         "200":
           description: HTML page with API information
@@ -221,21 +221,21 @@ paths:
             type: string
       summary: Get API information
       tags:
-      - info
+        - info
   /auth/confirm-reset:
     post:
       consumes:
-      - application/json
+        - application/json
       description: Reset password with token
       parameters:
-      - description: Confirm reset request
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/main.ConfirmResetRequest'
+        - description: Confirm reset request
+          in: body
+          name: request
+          required: true
+          schema:
+            $ref: '#/definitions/main.ConfirmResetRequest'
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -255,21 +255,21 @@ paths:
             type: object
       summary: Confirm password reset
       tags:
-      - auth
+        - auth
   /auth/login:
     post:
       consumes:
-      - application/json
+        - application/json
       description: Login with email and password
       parameters:
-      - description: User login data
-        in: body
-        name: user
-        required: true
-        schema:
-          $ref: '#/definitions/main.LoginRequest'
+        - description: User login data
+          in: body
+          name: user
+          required: true
+          schema:
+            $ref: '#/definitions/main.LoginRequest'
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -289,14 +289,14 @@ paths:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Login user
       tags:
-      - auth
+        - auth
   /auth/logout:
     post:
       consumes:
-      - application/json
+        - application/json
       description: Logout current user (client should discard token)
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -304,14 +304,14 @@ paths:
             $ref: '#/definitions/main.MessageResponse'
       summary: Logout user
       tags:
-      - auth
+        - auth
   /auth/profile:
     get:
       consumes:
-      - application/json
+        - application/json
       description: Get current user profile information
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -326,23 +326,23 @@ paths:
           schema:
             $ref: '#/definitions/main.ErrorResponse'
       security:
-      - BearerAuth: []
+        - BearerAuth: []
       summary: Get user profile
       tags:
-      - auth
+        - auth
     put:
       consumes:
-      - application/json
+        - application/json
       description: Update current user profile information
       parameters:
-      - description: Profile update data
-        in: body
-        name: profile
-        required: true
-        schema:
-          $ref: '#/definitions/main.UpdateProfileRequest'
+        - description: Profile update data
+          in: body
+          name: profile
+          required: true
+          schema:
+            $ref: '#/definitions/main.UpdateProfileRequest'
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -361,24 +361,24 @@ paths:
           schema:
             $ref: '#/definitions/main.ErrorResponse'
       security:
-      - BearerAuth: []
+        - BearerAuth: []
       summary: Update user profile
       tags:
-      - auth
+        - auth
   /auth/register:
     post:
       consumes:
-      - application/json
+        - application/json
       description: Register with email and password
       parameters:
-      - description: User registration data
-        in: body
-        name: user
-        required: true
-        schema:
-          $ref: '#/definitions/main.RegisterRequest'
+        - description: User registration data
+          in: body
+          name: user
+          required: true
+          schema:
+            $ref: '#/definitions/main.RegisterRequest'
       produces:
-      - application/json
+        - application/json
       responses:
         "201":
           description: Created
@@ -394,21 +394,21 @@ paths:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Register a new user
       tags:
-      - auth
+        - auth
   /auth/reset-password:
     post:
       consumes:
-      - application/json
+        - application/json
       description: Send password reset token for email
       parameters:
-      - description: Reset password request
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/main.ResetPasswordRequest'
+        - description: Reset password request
+          in: body
+          name: request
+          required: true
+          schema:
+            $ref: '#/definitions/main.ResetPasswordRequest'
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -428,20 +428,20 @@ paths:
             type: object
       summary: Request password reset
       tags:
-      - auth
+        - auth
   /game/{slug}:
     get:
       consumes:
-      - application/json
+        - application/json
       description: Returns the current state of a game
       parameters:
-      - description: Game slug identifier
-        in: path
-        name: slug
-        required: true
-        type: string
+        - description: Game slug identifier
+          in: path
+          name: slug
+          required: true
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -453,25 +453,25 @@ paths:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Get game state
       tags:
-      - game
+        - game
   /game/{slug}/{turn}:
     get:
       consumes:
-      - application/json
+        - application/json
       description: Returns the state of a game at a specific turn
       parameters:
-      - description: Game slug identifier
-        in: path
-        name: slug
-        required: true
-        type: string
-      - description: Turn number
-        in: path
-        name: turn
-        required: true
-        type: integer
+        - description: Game slug identifier
+          in: path
+          name: slug
+          required: true
+          type: string
+        - description: Turn number
+          in: path
+          name: turn
+          required: true
+          type: integer
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -483,20 +483,20 @@ paths:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Get specific turn
       tags:
-      - game
+        - game
   /game/{slug}/join:
     post:
       consumes:
-      - application/json
+        - application/json
       description: Join a game that is waiting for a second player (as black player)
       parameters:
-      - description: Game slug identifier
-        in: path
-        name: slug
-        required: true
-        type: string
+        - description: Game slug identifier
+          in: path
+          name: slug
+          required: true
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -516,26 +516,26 @@ paths:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Join a waiting game
       tags:
-      - game
+        - game
   /game/{slug}/move:
     post:
       consumes:
-      - application/json
+        - application/json
       description: Submit a move for a specific game
       parameters:
-      - description: Game slug identifier
-        in: path
-        name: slug
-        required: true
-        type: string
-      - description: Move details
-        in: body
-        name: move
-        required: true
-        schema:
-          $ref: '#/definitions/main.MoveRequest'
+        - description: Game slug identifier
+          in: path
+          name: slug
+          required: true
+          type: string
+        - description: Move details
+          in: body
+          name: move
+          required: true
+          schema:
+            $ref: '#/definitions/main.MoveRequest'
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -551,20 +551,20 @@ paths:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Make a move in a game
       tags:
-      - game
+        - game
   /game/new:
     get:
       consumes:
-      - application/json
+        - application/json
       description: Creates a new Tak game with the specified board size
       parameters:
-      - description: Game configuration
-        in: body
-        name: game
-        schema:
-          $ref: '#/definitions/main.CreateGameRequest'
+        - description: Game configuration
+          in: body
+          name: game
+          schema:
+            $ref: '#/definitions/main.CreateGameRequest'
       produces:
-      - application/json
+        - application/json
       responses:
         "307":
           description: Redirect to game URL
@@ -580,19 +580,19 @@ paths:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Create a new game
       tags:
-      - game
+        - game
     post:
       consumes:
-      - application/json
+        - application/json
       description: Creates a new Tak game with the specified board size
       parameters:
-      - description: Game configuration
-        in: body
-        name: game
-        schema:
-          $ref: '#/definitions/main.CreateGameRequest'
+        - description: Game configuration
+          in: body
+          name: game
+          schema:
+            $ref: '#/definitions/main.CreateGameRequest'
       produces:
-      - application/json
+        - application/json
       responses:
         "307":
           description: Redirect to game URL
@@ -608,14 +608,14 @@ paths:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Create a new game
       tags:
-      - game
+        - game
   /healthz:
     get:
       consumes:
-      - application/json
+        - application/json
       description: Returns service health status
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -623,7 +623,7 @@ paths:
             $ref: '#/definitions/main.HealthResponse'
       summary: Health check
       tags:
-      - health
+        - health
 securityDefinitions:
   BearerAuth:
     description: 'JWT token in format: Bearer {token}'

--- a/cmd/server/docs/swagger.yaml
+++ b/cmd/server/docs/swagger.yaml
@@ -215,10 +215,10 @@ paths:
   /:
     get:
       consumes:
-      - application/json
+        - application/json
       description: Returns basic API information and available endpoints
       produces:
-      - text/html
+        - text/html
       responses:
         "200":
           description: HTML page with API information
@@ -226,21 +226,21 @@ paths:
             type: string
       summary: Get API information
       tags:
-      - info
+        - info
   /auth/confirm-reset:
     post:
       consumes:
-      - application/json
+        - application/json
       description: Reset password with token
       parameters:
-      - description: Confirm reset request
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/main.ConfirmResetRequest'
+        - description: Confirm reset request
+          in: body
+          name: request
+          required: true
+          schema:
+            $ref: '#/definitions/main.ConfirmResetRequest'
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -260,21 +260,21 @@ paths:
             type: object
       summary: Confirm password reset
       tags:
-      - auth
+        - auth
   /auth/login:
     post:
       consumes:
-      - application/json
+        - application/json
       description: Login with email and password
       parameters:
-      - description: User login data
-        in: body
-        name: user
-        required: true
-        schema:
-          $ref: '#/definitions/main.LoginRequest'
+        - description: User login data
+          in: body
+          name: user
+          required: true
+          schema:
+            $ref: '#/definitions/main.LoginRequest'
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -294,14 +294,14 @@ paths:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Login user
       tags:
-      - auth
+        - auth
   /auth/logout:
     post:
       consumes:
-      - application/json
+        - application/json
       description: Logout current user (client should discard token)
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -309,14 +309,14 @@ paths:
             $ref: '#/definitions/main.MessageResponse'
       summary: Logout user
       tags:
-      - auth
+        - auth
   /auth/profile:
     get:
       consumes:
-      - application/json
+        - application/json
       description: Get current user profile information
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -331,23 +331,23 @@ paths:
           schema:
             $ref: '#/definitions/main.ErrorResponse'
       security:
-      - BearerAuth: []
+        - BearerAuth: []
       summary: Get user profile
       tags:
-      - auth
+        - auth
     put:
       consumes:
-      - application/json
+        - application/json
       description: Update current user profile information
       parameters:
-      - description: Profile update data
-        in: body
-        name: profile
-        required: true
-        schema:
-          $ref: '#/definitions/main.UpdateProfileRequest'
+        - description: Profile update data
+          in: body
+          name: profile
+          required: true
+          schema:
+            $ref: '#/definitions/main.UpdateProfileRequest'
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -366,24 +366,24 @@ paths:
           schema:
             $ref: '#/definitions/main.ErrorResponse'
       security:
-      - BearerAuth: []
+        - BearerAuth: []
       summary: Update user profile
       tags:
-      - auth
+        - auth
   /auth/register:
     post:
       consumes:
-      - application/json
+        - application/json
       description: Register with email and password
       parameters:
-      - description: User registration data
-        in: body
-        name: user
-        required: true
-        schema:
-          $ref: '#/definitions/main.RegisterRequest'
+        - description: User registration data
+          in: body
+          name: user
+          required: true
+          schema:
+            $ref: '#/definitions/main.RegisterRequest'
       produces:
-      - application/json
+        - application/json
       responses:
         "201":
           description: Created
@@ -399,21 +399,21 @@ paths:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Register a new user
       tags:
-      - auth
+        - auth
   /auth/reset-password:
     post:
       consumes:
-      - application/json
+        - application/json
       description: Send password reset token for email
       parameters:
-      - description: Reset password request
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/main.ResetPasswordRequest'
+        - description: Reset password request
+          in: body
+          name: request
+          required: true
+          schema:
+            $ref: '#/definitions/main.ResetPasswordRequest'
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -433,20 +433,20 @@ paths:
             type: object
       summary: Request password reset
       tags:
-      - auth
+        - auth
   /game/{slug}:
     get:
       consumes:
-      - application/json
+        - application/json
       description: Returns the current state of a game
       parameters:
-      - description: Game slug identifier
-        in: path
-        name: slug
-        required: true
-        type: string
+        - description: Game slug identifier
+          in: path
+          name: slug
+          required: true
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -458,25 +458,25 @@ paths:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Get game state
       tags:
-      - game
+        - game
   /game/{slug}/{turn}:
     get:
       consumes:
-      - application/json
+        - application/json
       description: Returns the state of a game at a specific turn
       parameters:
-      - description: Game slug identifier
-        in: path
-        name: slug
-        required: true
-        type: string
-      - description: Turn number
-        in: path
-        name: turn
-        required: true
-        type: integer
+        - description: Game slug identifier
+          in: path
+          name: slug
+          required: true
+          type: string
+        - description: Turn number
+          in: path
+          name: turn
+          required: true
+          type: integer
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -488,20 +488,20 @@ paths:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Get specific turn
       tags:
-      - game
+        - game
   /game/{slug}/join:
     post:
       consumes:
-      - application/json
+        - application/json
       description: Join a game that is waiting for a second player (as black player)
       parameters:
-      - description: Game slug identifier
-        in: path
-        name: slug
-        required: true
-        type: string
+        - description: Game slug identifier
+          in: path
+          name: slug
+          required: true
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -521,26 +521,26 @@ paths:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Join a waiting game
       tags:
-      - game
+        - game
   /game/{slug}/move:
     post:
       consumes:
-      - application/json
+        - application/json
       description: Submit a move for a specific game
       parameters:
-      - description: Game slug identifier
-        in: path
-        name: slug
-        required: true
-        type: string
-      - description: Move details
-        in: body
-        name: move
-        required: true
-        schema:
-          $ref: '#/definitions/main.MoveRequest'
+        - description: Game slug identifier
+          in: path
+          name: slug
+          required: true
+          type: string
+        - description: Move details
+          in: body
+          name: move
+          required: true
+          schema:
+            $ref: '#/definitions/main.MoveRequest'
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -556,20 +556,20 @@ paths:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Make a move in a game
       tags:
-      - game
+        - game
   /game/new:
     get:
       consumes:
-      - application/json
+        - application/json
       description: Creates a new Tak game with the specified board size
       parameters:
-      - description: Game configuration
-        in: body
-        name: game
-        schema:
-          $ref: '#/definitions/main.CreateGameRequest'
+        - description: Game configuration
+          in: body
+          name: game
+          schema:
+            $ref: '#/definitions/main.CreateGameRequest'
       produces:
-      - application/json
+        - application/json
       responses:
         "307":
           description: Redirect to game URL
@@ -585,19 +585,19 @@ paths:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Create a new game
       tags:
-      - game
+        - game
     post:
       consumes:
-      - application/json
+        - application/json
       description: Creates a new Tak game with the specified board size
       parameters:
-      - description: Game configuration
-        in: body
-        name: game
-        schema:
-          $ref: '#/definitions/main.CreateGameRequest'
+        - description: Game configuration
+          in: body
+          name: game
+          schema:
+            $ref: '#/definitions/main.CreateGameRequest'
       produces:
-      - application/json
+        - application/json
       responses:
         "307":
           description: Redirect to game URL
@@ -613,14 +613,14 @@ paths:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Create a new game
       tags:
-      - game
+        - game
   /healthz:
     get:
       consumes:
-      - application/json
+        - application/json
       description: Returns service health status
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -628,7 +628,7 @@ paths:
             $ref: '#/definitions/main.HealthResponse'
       summary: Health check
       tags:
-      - health
+        - health
 securityDefinitions:
   BearerAuth:
     description: 'JWT token in format: Bearer {token}'

--- a/tps.go
+++ b/tps.go
@@ -1,0 +1,131 @@
+package gotak
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ParseTPS parses a Tak Position System string and returns the resulting
+// board state, the player to move next, and the (1-indexed) move number.
+//
+// The TPS format is `<position> <player> <move>`, where position is a
+// slash-separated list of rows from top (highest rank) to bottom (rank 1).
+// Each row is a comma-separated list of squares. An empty square is `x`,
+// optionally followed by a count (`x3` = three empty squares in a row).
+// A stack is encoded as a sequence of `1` (white) / `2` (black) digits,
+// bottom stone first, optionally suffixed with a stone type for the top
+// stone (`S` for standing, `C` for capstone; default is flat).
+//
+// Example: `x5/x5/x5/x5/1,1,1,1,1 1 5` — a 5x5 board with white flats on
+// the bottom row, white to move, on move 5.
+func ParseTPS(tps string) (*Board, int, int64, error) {
+	fields := strings.Fields(strings.TrimSpace(tps))
+	if len(fields) != 3 {
+		return nil, 0, 0, fmt.Errorf("tps must have 3 space-separated fields, got %d", len(fields))
+	}
+
+	rows := strings.Split(fields[0], "/")
+	size := int64(len(rows))
+	if size < 4 || size > 9 {
+		return nil, 0, 0, fmt.Errorf("tps row count %d is out of supported range [4,9]", size)
+	}
+
+	player, err := strconv.Atoi(fields[1])
+	if err != nil || (player != PlayerWhite && player != PlayerBlack) {
+		return nil, 0, 0, fmt.Errorf("tps player field must be 1 or 2, got %q", fields[1])
+	}
+
+	move, err := strconv.ParseInt(fields[2], 10, 64)
+	if err != nil || move < 1 {
+		return nil, 0, 0, fmt.Errorf("tps move number must be a positive integer, got %q", fields[2])
+	}
+
+	b := &Board{Size: size}
+	if err := b.Init(); err != nil {
+		return nil, 0, 0, err
+	}
+
+	// Rows are written top-to-bottom in TPS, but the board is indexed
+	// bottom-to-top, so the first row in the string is rank `size`.
+	for i, row := range rows {
+		rank := size - int64(i)
+		col := int64(0)
+
+		cells := strings.Split(row, ",")
+		for _, cell := range cells {
+			cell = strings.TrimSpace(cell)
+			if cell == "" {
+				return nil, 0, 0, fmt.Errorf("empty cell in tps row %q", row)
+			}
+
+			if cell[0] == 'x' {
+				count := int64(1)
+				if len(cell) > 1 {
+					n, err := strconv.ParseInt(cell[1:], 10, 64)
+					if err != nil || n < 1 {
+						return nil, 0, 0, fmt.Errorf("invalid empty-square count %q", cell)
+					}
+					count = n
+				}
+				col += count
+				continue
+			}
+
+			stack, err := parseTPSStack(cell)
+			if err != nil {
+				return nil, 0, 0, fmt.Errorf("row %q: %w", row, err)
+			}
+
+			if col >= size {
+				return nil, 0, 0, fmt.Errorf("row %q has more squares than board size %d", row, size)
+			}
+			square := fmt.Sprintf("%c%d", 'a'+col, rank)
+			b.Squares[square] = stack
+			col++
+		}
+
+		if col != size {
+			return nil, 0, 0, fmt.Errorf("row %q describes %d squares, expected %d", row, col, size)
+		}
+	}
+
+	return b, player, move, nil
+}
+
+func parseTPSStack(cell string) ([]*Stone, error) {
+	topType := StoneFlat
+	body := cell
+	switch last := body[len(body)-1]; last {
+	case 'S':
+		topType = StoneStanding
+		body = body[:len(body)-1]
+	case 'C':
+		topType = StoneCap
+		body = body[:len(body)-1]
+	}
+
+	if body == "" {
+		return nil, fmt.Errorf("stack %q has a type marker but no stones", cell)
+	}
+
+	stack := make([]*Stone, 0, len(body))
+	for i := 0; i < len(body); i++ {
+		var p int
+		switch body[i] {
+		case '1':
+			p = PlayerWhite
+		case '2':
+			p = PlayerBlack
+		default:
+			return nil, fmt.Errorf("stack %q contains non-stone character %q", cell, string(body[i]))
+		}
+		stoneType := StoneFlat
+		if i == len(body)-1 {
+			stoneType = topType
+		}
+		stack = append(stack, &Stone{Type: stoneType, Player: p})
+	}
+
+	return stack, nil
+}

--- a/tps_test.go
+++ b/tps_test.go
@@ -1,0 +1,72 @@
+package gotak
+
+import "testing"
+
+func TestParseTPS_empty(t *testing.T) {
+	b, player, move, err := ParseTPS("x5/x5/x5/x5/x5 1 1")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if b.Size != 5 {
+		t.Errorf("size = %d, want 5", b.Size)
+	}
+	if player != PlayerWhite {
+		t.Errorf("player = %d, want %d", player, PlayerWhite)
+	}
+	if move != 1 {
+		t.Errorf("move = %d, want 1", move)
+	}
+	_ = b.IterateOverSquares(func(_ string, stones []*Stone) error {
+		if len(stones) != 0 {
+			t.Errorf("expected empty board, got %d stones", len(stones))
+		}
+		return nil
+	})
+}
+
+func TestParseTPS_stacksAndTypes(t *testing.T) {
+	b, _, _, err := ParseTPS("x4/x4/x4/1,12S,1C,x 2 3")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if b.Size != 4 {
+		t.Fatalf("size = %d, want 4", b.Size)
+	}
+
+	if len(b.Squares["a1"]) != 1 || b.Squares["a1"][0].Type != StoneFlat || b.Squares["a1"][0].Player != PlayerWhite {
+		t.Errorf("a1 = %+v, want single white flat", b.Squares["a1"])
+	}
+
+	b1 := b.Squares["b1"]
+	if len(b1) != 2 ||
+		b1[0].Player != PlayerWhite || b1[0].Type != StoneFlat ||
+		b1[1].Player != PlayerBlack || b1[1].Type != StoneStanding {
+		t.Errorf("b1 = %+v, want [W flat, B standing]", b1)
+	}
+
+	c1 := b.Squares["c1"]
+	if len(c1) != 1 || c1[0].Player != PlayerWhite || c1[0].Type != StoneCap {
+		t.Errorf("c1 = %+v, want white capstone", c1)
+	}
+
+	if len(b.Squares["d1"]) != 0 {
+		t.Errorf("d1 = %+v, want empty", b.Squares["d1"])
+	}
+}
+
+func TestParseTPS_invalid(t *testing.T) {
+	cases := []string{
+		"",                          // empty
+		"x5/x5/x5/x5/x5",            // missing player/move
+		"x5/x5/x5/x4 1 1",           // row too short
+		"x5/x5/x5/x5/1,1,1,1,1 3 1", // bad player
+		"x5/x5/x5/x5/1,1,1,1,1 1 0", // bad move
+		"x5/x5/x5/x5/3,1,1,1,1 1 1", // bad stone char
+		"x3/x3/x3 1 1",              // size below supported range
+	}
+	for _, c := range cases {
+		if _, _, _, err := ParseTPS(c); err == nil {
+			t.Errorf("ParseTPS(%q) want error, got none", c)
+		}
+	}
+}


### PR DESCRIPTION
Closes #39.

Adds `gotak.ParseTPS` that turns a Tak Position System string into a populated `Board`, and replaces the empty `TestFindRoad` stub with table-driven cases (horizontal/vertical/L-shaped roads, broken roads via standing stones, opponent-topped stacks).