### PR TITLE
feat: parse PTN branch notation

### DIFF
--- a/branch_test.go
+++ b/branch_test.go
@@ -1,0 +1,89 @@
+package gotak
+
+import "testing"
+
+func TestParseTurnLabel(t *testing.T) {
+	cases := []struct {
+		in     string
+		num    int64
+		branch string
+		ok     bool
+	}{
+		{"1", 1, "", true},
+		{"12", 12, "", true},
+		{"1a", 1, "a", true},
+		{"42c", 42, "c", true},
+		{"", 0, "", false},
+		{"a1", 0, "", false},
+		{"1ab", 0, "", false},
+		{"1A", 0, "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			n, br, ok := parseTurnLabel(c.in)
+			if ok != c.ok || n != c.num || br != c.branch {
+				t.Errorf("parseTurnLabel(%q) = (%d,%q,%v), want (%d,%q,%v)", c.in, n, br, ok, c.num, c.branch, c.ok)
+			}
+		})
+	}
+}
+
+func TestParsePTN_branches(t *testing.T) {
+	ptn := []byte(`[Size "5"]
+[Player1 "alice"]
+[Player2 "bob"]
+
+1. a1 e5
+2. b2 d4
+3. c3 c4
+
+{Alternate continuation}
+1a. a1 e5
+2a. b2 d4
+3a. e1 a5
+`)
+
+	g, err := ParsePTN(ptn)
+	if err != nil {
+		t.Fatalf("ParsePTN: %v", err)
+	}
+
+	main := g.TurnsInBranch("")
+	if len(main) != 3 {
+		t.Errorf("main branch has %d turns, want 3", len(main))
+	}
+
+	a := g.TurnsInBranch("a")
+	if len(a) != 3 {
+		t.Errorf("branch 'a' has %d turns, want 3", len(a))
+	}
+
+	branches := g.Branches()
+	if len(branches) != 1 || branches[0] != "a" {
+		t.Errorf("Branches() = %v, want [a]", branches)
+	}
+
+	// Branch turns should keep their original numbering on parse.
+	for i, turn := range a {
+		if turn.Number != int64(i+1) {
+			t.Errorf("branch a turn %d has Number=%d, want %d", i, turn.Number, i+1)
+		}
+		if turn.Branch != "a" {
+			t.Errorf("branch a turn %d has Branch=%q, want \"a\"", i, turn.Branch)
+		}
+	}
+}
+
+func TestTurnText_branch(t *testing.T) {
+	turn := &Turn{
+		Number: 2,
+		Branch: "b",
+		First:  &Move{Text: "a1"},
+		Second: &Move{Text: "e5"},
+	}
+	got := turn.Text()
+	want := "2b. a1 e5"
+	if got != want {
+		t.Errorf("Text() = %q, want %q", got, want)
+	}
+}

--- a/cmd/server/docs/swagger.json
+++ b/cmd/server/docs/swagger.json
@@ -1,959 +1,959 @@
 {
-    "swagger": "2.0",
-    "info": {
-        "description": "A Tak game server API with authentication",
-        "title": "GoTak API",
-        "contact": {
-            "name": "API Support",
-            "url": "http://github.com/icco/gotak"
-        },
-        "license": {
-            "name": "MIT",
-            "url": "https://github.com/icco/gotak/blob/main/LICENSE"
-        },
-        "version": "1.0"
+  "swagger": "2.0",
+  "info": {
+    "description": "A Tak game server API with authentication",
+    "title": "GoTak API",
+    "contact": {
+      "name": "API Support",
+      "url": "http://github.com/icco/gotak"
     },
-    "host": "gotak.app",
-    "basePath": "/",
-    "paths": {
-        "/": {
-            "get": {
-                "description": "Returns basic API information and available endpoints",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "text/html"
-                ],
-                "tags": [
-                    "info"
-                ],
-                "summary": "Get API information",
-                "responses": {
-                    "200": {
-                        "description": "HTML page with API information",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/auth/confirm-reset": {
-            "post": {
-                "description": "Reset password with token",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "auth"
-                ],
-                "summary": "Confirm password reset",
-                "parameters": [
-                    {
-                        "description": "Confirm reset request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/main.ConfirmResetRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/main.MessageResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/auth/login": {
-            "post": {
-                "description": "Login with email and password",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "auth"
-                ],
-                "summary": "Login user",
-                "parameters": [
-                    {
-                        "description": "User login data",
-                        "name": "user",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/main.LoginRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/main.AuthResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/auth/logout": {
-            "post": {
-                "description": "Logout current user (client should discard token)",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "auth"
-                ],
-                "summary": "Logout user",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/main.MessageResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/auth/profile": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Get current user profile information",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "auth"
-                ],
-                "summary": "Get user profile",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/main.User"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            },
-            "put": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Update current user profile information",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "auth"
-                ],
-                "summary": "Update user profile",
-                "parameters": [
-                    {
-                        "description": "Profile update data",
-                        "name": "profile",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/main.UpdateProfileRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/main.User"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/auth/register": {
-            "post": {
-                "description": "Register with email and password",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "auth"
-                ],
-                "summary": "Register a new user",
-                "parameters": [
-                    {
-                        "description": "User registration data",
-                        "name": "user",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/main.RegisterRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/main.MessageResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/auth/reset-password": {
-            "post": {
-                "description": "Send password reset token for email",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "auth"
-                ],
-                "summary": "Request password reset",
-                "parameters": [
-                    {
-                        "description": "Reset password request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/main.ResetPasswordRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/main.MessageResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/game/new": {
-            "get": {
-                "description": "Creates a new Tak game with the specified board size",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "game"
-                ],
-                "summary": "Create a new game",
-                "parameters": [
-                    {
-                        "description": "Game configuration",
-                        "name": "game",
-                        "in": "body",
-                        "schema": {
-                            "$ref": "#/definitions/main.CreateGameRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "307": {
-                        "description": "Redirect to game URL",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            },
-            "post": {
-                "description": "Creates a new Tak game with the specified board size",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "game"
-                ],
-                "summary": "Create a new game",
-                "parameters": [
-                    {
-                        "description": "Game configuration",
-                        "name": "game",
-                        "in": "body",
-                        "schema": {
-                            "$ref": "#/definitions/main.CreateGameRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "307": {
-                        "description": "Redirect to game URL",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/game/{slug}": {
-            "get": {
-                "description": "Returns the current state of a game",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "game"
-                ],
-                "summary": "Get game state",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Game slug identifier",
-                        "name": "slug",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/gotak.Game"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/game/{slug}/join": {
-            "post": {
-                "description": "Join a game that is waiting for a second player (as black player)",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "game"
-                ],
-                "summary": "Join a waiting game",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Game slug identifier",
-                        "name": "slug",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/main.MessageResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/game/{slug}/move": {
-            "post": {
-                "description": "Submit a move for a specific game",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "game"
-                ],
-                "summary": "Make a move in a game",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Game slug identifier",
-                        "name": "slug",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "description": "Move details",
-                        "name": "move",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/main.MoveRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/gotak.Game"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/game/{slug}/{turn}": {
-            "get": {
-                "description": "Returns the state of a game at a specific turn",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "game"
-                ],
-                "summary": "Get specific turn",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Game slug identifier",
-                        "name": "slug",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Turn number",
-                        "name": "turn",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/gotak.Turn"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/main.ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/healthz": {
-            "get": {
-                "description": "Returns service health status",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "health"
-                ],
-                "summary": "Health check",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/main.HealthResponse"
-                        }
-                    }
-                }
-            }
-        }
+    "license": {
+      "name": "MIT",
+      "url": "https://github.com/icco/gotak/blob/main/LICENSE"
     },
-    "definitions": {
-        "gotak.Board": {
-            "type": "object",
-            "properties": {
-                "size": {
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "squares": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/definitions/gotak.Stone"
-                        }
-                    }
-                }
+    "version": "1.0"
+  },
+  "host": "gotak.app",
+  "basePath": "/",
+  "paths": {
+    "/": {
+      "get": {
+        "description": "Returns basic API information and available endpoints",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "text/html"
+        ],
+        "tags": [
+          "info"
+        ],
+        "summary": "Get API information",
+        "responses": {
+          "200": {
+            "description": "HTML page with API information",
+            "schema": {
+              "type": "string"
             }
-        },
-        "gotak.Game": {
-            "type": "object",
-            "properties": {
-                "board": {
-                    "$ref": "#/definitions/gotak.Board"
-                },
-                "id": {
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "meta": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/gotak.Tag"
-                    }
-                },
-                "slug": {
-                    "type": "string"
-                },
-                "turns": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/gotak.Turn"
-                    }
-                }
-            }
-        },
-        "gotak.Move": {
-            "type": "object",
-            "properties": {
-                "moveCount": {
-                    "description": "Move only",
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "moveDirection": {
-                    "type": "string"
-                },
-                "moveDropCounts": {
-                    "type": "array",
-                    "items": {
-                        "type": "integer",
-                        "format": "int64"
-                    }
-                },
-                "square": {
-                    "type": "string"
-                },
-                "stone": {
-                    "description": "Both Drop and Move",
-                    "type": "string"
-                },
-                "text": {
-                    "type": "string"
-                }
-            }
-        },
-        "gotak.Stone": {
-            "type": "object",
-            "properties": {
-                "player": {
-                    "type": "integer"
-                },
-                "type": {
-                    "type": "string"
-                }
-            }
-        },
-        "gotak.Tag": {
-            "type": "object",
-            "properties": {
-                "key": {
-                    "type": "string"
-                },
-                "value": {
-                    "type": "string"
-                }
-            }
-        },
-        "gotak.Turn": {
-            "type": "object",
-            "properties": {
-                "comment": {
-                    "type": "string"
-                },
-                "first": {
-                    "$ref": "#/definitions/gotak.Move"
-                },
-                "number": {
-                    "type": "integer",
-                    "format": "int64"
-                },
-                "result": {
-                    "type": "string"
-                },
-                "second": {
-                    "$ref": "#/definitions/gotak.Move"
-                }
-            }
-        },
-        "main.AuthResponse": {
-            "type": "object",
-            "properties": {
-                "token": {
-                    "type": "string"
-                },
-                "user": {
-                    "$ref": "#/definitions/main.User"
-                }
-            }
-        },
-        "main.ConfirmResetRequest": {
-            "type": "object",
-            "properties": {
-                "new_password": {
-                    "type": "string",
-                    "example": "newsecretpassword"
-                },
-                "token": {
-                    "type": "string",
-                    "example": "reset-token-here"
-                }
-            }
-        },
-        "main.CreateGameRequest": {
-            "type": "object",
-            "properties": {
-                "size": {
-                    "type": "string",
-                    "example": "8"
-                }
-            }
-        },
-        "main.ErrorResponse": {
-            "type": "object",
-            "properties": {
-                "error": {
-                    "type": "string",
-                    "example": "Something went wrong"
-                }
-            }
-        },
-        "main.HealthResponse": {
-            "type": "object",
-            "properties": {
-                "branch": {
-                    "type": "string",
-                    "example": "main"
-                },
-                "healthy": {
-                    "type": "string",
-                    "example": "true"
-                },
-                "revision": {
-                    "type": "string",
-                    "example": "abc123def"
-                },
-                "tag": {
-                    "type": "string",
-                    "example": "v1.0.0"
-                }
-            }
-        },
-        "main.LoginRequest": {
-            "type": "object",
-            "properties": {
-                "email": {
-                    "type": "string",
-                    "example": "user@example.com"
-                },
-                "password": {
-                    "type": "string",
-                    "example": "secretpassword"
-                }
-            }
-        },
-        "main.MessageResponse": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string",
-                    "example": "Operation successful"
-                }
-            }
-        },
-        "main.MoveRequest": {
-            "type": "object",
-            "properties": {
-                "move": {
-                    "type": "string",
-                    "example": "c3"
-                },
-                "player": {
-                    "type": "integer",
-                    "example": 1
-                },
-                "turn": {
-                    "type": "integer",
-                    "example": 1
-                }
-            }
-        },
-        "main.RegisterRequest": {
-            "type": "object",
-            "properties": {
-                "email": {
-                    "type": "string",
-                    "example": "user@example.com"
-                },
-                "name": {
-                    "type": "string",
-                    "example": "John Doe"
-                },
-                "password": {
-                    "type": "string",
-                    "example": "secretpassword"
-                }
-            }
-        },
-        "main.ResetPasswordRequest": {
-            "type": "object",
-            "properties": {
-                "email": {
-                    "type": "string",
-                    "example": "user@example.com"
-                }
-            }
-        },
-        "main.UpdateProfileRequest": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "preferences": {
-                    "type": "string"
-                }
-            }
-        },
-        "main.User": {
-            "type": "object",
-            "properties": {
-                "avatar_url": {
-                    "type": "string"
-                },
-                "created_at": {
-                    "type": "string"
-                },
-                "email": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "preferences": {
-                    "type": "string"
-                },
-                "provider": {
-                    "type": "string"
-                },
-                "provider_id": {
-                    "type": "string"
-                },
-                "updated_at": {
-                    "type": "string"
-                }
-            }
+          }
         }
+      }
     },
-    "securityDefinitions": {
-        "BearerAuth": {
-            "description": "JWT token in format: Bearer {token}",
-            "type": "apiKey",
-            "name": "Authorization",
-            "in": "header"
+    "/auth/confirm-reset": {
+      "post": {
+        "description": "Reset password with token",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "auth"
+        ],
+        "summary": "Confirm password reset",
+        "parameters": [
+          {
+            "description": "Confirm reset request",
+            "name": "request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/main.ConfirmResetRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/main.MessageResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
         }
+      }
+    },
+    "/auth/login": {
+      "post": {
+        "description": "Login with email and password",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "auth"
+        ],
+        "summary": "Login user",
+        "parameters": [
+          {
+            "description": "User login data",
+            "name": "user",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/main.LoginRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/main.AuthResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/auth/logout": {
+      "post": {
+        "description": "Logout current user (client should discard token)",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "auth"
+        ],
+        "summary": "Logout user",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/main.MessageResponse"
+            }
+          }
+        }
+      }
+    },
+    "/auth/profile": {
+      "get": {
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "description": "Get current user profile information",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "auth"
+        ],
+        "summary": "Get user profile",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/main.User"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "description": "Update current user profile information",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "auth"
+        ],
+        "summary": "Update user profile",
+        "parameters": [
+          {
+            "description": "Profile update data",
+            "name": "profile",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/main.UpdateProfileRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/main.User"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/auth/register": {
+      "post": {
+        "description": "Register with email and password",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "auth"
+        ],
+        "summary": "Register a new user",
+        "parameters": [
+          {
+            "description": "User registration data",
+            "name": "user",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/main.RegisterRequest"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "schema": {
+              "$ref": "#/definitions/main.MessageResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/auth/reset-password": {
+      "post": {
+        "description": "Send password reset token for email",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "auth"
+        ],
+        "summary": "Request password reset",
+        "parameters": [
+          {
+            "description": "Reset password request",
+            "name": "request",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/main.ResetPasswordRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/main.MessageResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/game/new": {
+      "get": {
+        "description": "Creates a new Tak game with the specified board size",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "game"
+        ],
+        "summary": "Create a new game",
+        "parameters": [
+          {
+            "description": "Game configuration",
+            "name": "game",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/main.CreateGameRequest"
+            }
+          }
+        ],
+        "responses": {
+          "307": {
+            "description": "Redirect to game URL",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a new Tak game with the specified board size",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "game"
+        ],
+        "summary": "Create a new game",
+        "parameters": [
+          {
+            "description": "Game configuration",
+            "name": "game",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/main.CreateGameRequest"
+            }
+          }
+        ],
+        "responses": {
+          "307": {
+            "description": "Redirect to game URL",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/game/{slug}": {
+      "get": {
+        "description": "Returns the current state of a game",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "game"
+        ],
+        "summary": "Get game state",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Game slug identifier",
+            "name": "slug",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/gotak.Game"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/game/{slug}/join": {
+      "post": {
+        "description": "Join a game that is waiting for a second player (as black player)",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "game"
+        ],
+        "summary": "Join a waiting game",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Game slug identifier",
+            "name": "slug",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/main.MessageResponse"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/game/{slug}/move": {
+      "post": {
+        "description": "Submit a move for a specific game",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "game"
+        ],
+        "summary": "Make a move in a game",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Game slug identifier",
+            "name": "slug",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "Move details",
+            "name": "move",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/main.MoveRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/gotak.Game"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/game/{slug}/{turn}": {
+      "get": {
+        "description": "Returns the state of a game at a specific turn",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "game"
+        ],
+        "summary": "Get specific turn",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Game slug identifier",
+            "name": "slug",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "integer",
+            "description": "Turn number",
+            "name": "turn",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/gotak.Turn"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/main.ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/healthz": {
+      "get": {
+        "description": "Returns service health status",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "health"
+        ],
+        "summary": "Health check",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/main.HealthResponse"
+            }
+          }
+        }
+      }
     }
+  },
+  "definitions": {
+    "gotak.Board": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "squares": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/gotak.Stone"
+            }
+          }
+        }
+      }
+    },
+    "gotak.Game": {
+      "type": "object",
+      "properties": {
+        "board": {
+          "$ref": "#/definitions/gotak.Board"
+        },
+        "id": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "meta": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/gotak.Tag"
+          }
+        },
+        "slug": {
+          "type": "string"
+        },
+        "turns": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/gotak.Turn"
+          }
+        }
+      }
+    },
+    "gotak.Move": {
+      "type": "object",
+      "properties": {
+        "moveCount": {
+          "description": "Move only",
+          "type": "integer",
+          "format": "int64"
+        },
+        "moveDirection": {
+          "type": "string"
+        },
+        "moveDropCounts": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "square": {
+          "type": "string"
+        },
+        "stone": {
+          "description": "Both Drop and Move",
+          "type": "string"
+        },
+        "text": {
+          "type": "string"
+        }
+      }
+    },
+    "gotak.Stone": {
+      "type": "object",
+      "properties": {
+        "player": {
+          "type": "integer"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "gotak.Tag": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "gotak.Turn": {
+      "type": "object",
+      "properties": {
+        "comment": {
+          "type": "string"
+        },
+        "first": {
+          "$ref": "#/definitions/gotak.Move"
+        },
+        "number": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "result": {
+          "type": "string"
+        },
+        "second": {
+          "$ref": "#/definitions/gotak.Move"
+        }
+      }
+    },
+    "main.AuthResponse": {
+      "type": "object",
+      "properties": {
+        "token": {
+          "type": "string"
+        },
+        "user": {
+          "$ref": "#/definitions/main.User"
+        }
+      }
+    },
+    "main.ConfirmResetRequest": {
+      "type": "object",
+      "properties": {
+        "new_password": {
+          "type": "string",
+          "example": "newsecretpassword"
+        },
+        "token": {
+          "type": "string",
+          "example": "reset-token-here"
+        }
+      }
+    },
+    "main.CreateGameRequest": {
+      "type": "object",
+      "properties": {
+        "size": {
+          "type": "string",
+          "example": "8"
+        }
+      }
+    },
+    "main.ErrorResponse": {
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "string",
+          "example": "Something went wrong"
+        }
+      }
+    },
+    "main.HealthResponse": {
+      "type": "object",
+      "properties": {
+        "branch": {
+          "type": "string",
+          "example": "main"
+        },
+        "healthy": {
+          "type": "string",
+          "example": "true"
+        },
+        "revision": {
+          "type": "string",
+          "example": "abc123def"
+        },
+        "tag": {
+          "type": "string",
+          "example": "v1.0.0"
+        }
+      }
+    },
+    "main.LoginRequest": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "example": "user@example.com"
+        },
+        "password": {
+          "type": "string",
+          "example": "secretpassword"
+        }
+      }
+    },
+    "main.MessageResponse": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string",
+          "example": "Operation successful"
+        }
+      }
+    },
+    "main.MoveRequest": {
+      "type": "object",
+      "properties": {
+        "move": {
+          "type": "string",
+          "example": "c3"
+        },
+        "player": {
+          "type": "integer",
+          "example": 1
+        },
+        "turn": {
+          "type": "integer",
+          "example": 1
+        }
+      }
+    },
+    "main.RegisterRequest": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "example": "user@example.com"
+        },
+        "name": {
+          "type": "string",
+          "example": "John Doe"
+        },
+        "password": {
+          "type": "string",
+          "example": "secretpassword"
+        }
+      }
+    },
+    "main.ResetPasswordRequest": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "example": "user@example.com"
+        }
+      }
+    },
+    "main.UpdateProfileRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "preferences": {
+          "type": "string"
+        }
+      }
+    },
+    "main.User": {
+      "type": "object",
+      "properties": {
+        "avatar_url": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        },
+        "preferences": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "provider_id": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "securityDefinitions": {
+    "BearerAuth": {
+      "description": "JWT token in format: Bearer {token}",
+      "type": "apiKey",
+      "name": "Authorization",
+      "in": "header"
+    }
+  }
 }

--- a/cmd/server/docs/swagger.yaml
+++ b/cmd/server/docs/swagger.yaml
@@ -210,10 +210,10 @@ paths:
   /:
     get:
       consumes:
-      - application/json
+        - application/json
       description: Returns basic API information and available endpoints
       produces:
-      - text/html
+        - text/html
       responses:
         "200":
           description: HTML page with API information
@@ -221,21 +221,21 @@ paths:
             type: string
       summary: Get API information
       tags:
-      - info
+        - info
   /auth/confirm-reset:
     post:
       consumes:
-      - application/json
+        - application/json
       description: Reset password with token
       parameters:
-      - description: Confirm reset request
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/main.ConfirmResetRequest'
+        - description: Confirm reset request
+          in: body
+          name: request
+          required: true
+          schema:
+            $ref: '#/definitions/main.ConfirmResetRequest'
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -255,21 +255,21 @@ paths:
             type: object
       summary: Confirm password reset
       tags:
-      - auth
+        - auth
   /auth/login:
     post:
       consumes:
-      - application/json
+        - application/json
       description: Login with email and password
       parameters:
-      - description: User login data
-        in: body
-        name: user
-        required: true
-        schema:
-          $ref: '#/definitions/main.LoginRequest'
+        - description: User login data
+          in: body
+          name: user
+          required: true
+          schema:
+            $ref: '#/definitions/main.LoginRequest'
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -289,14 +289,14 @@ paths:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Login user
       tags:
-      - auth
+        - auth
   /auth/logout:
     post:
       consumes:
-      - application/json
+        - application/json
       description: Logout current user (client should discard token)
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -304,14 +304,14 @@ paths:
             $ref: '#/definitions/main.MessageResponse'
       summary: Logout user
       tags:
-      - auth
+        - auth
   /auth/profile:
     get:
       consumes:
-      - application/json
+        - application/json
       description: Get current user profile information
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -326,23 +326,23 @@ paths:
           schema:
             $ref: '#/definitions/main.ErrorResponse'
       security:
-      - BearerAuth: []
+        - BearerAuth: []
       summary: Get user profile
       tags:
-      - auth
+        - auth
     put:
       consumes:
-      - application/json
+        - application/json
       description: Update current user profile information
       parameters:
-      - description: Profile update data
-        in: body
-        name: profile
-        required: true
-        schema:
-          $ref: '#/definitions/main.UpdateProfileRequest'
+        - description: Profile update data
+          in: body
+          name: profile
+          required: true
+          schema:
+            $ref: '#/definitions/main.UpdateProfileRequest'
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -361,24 +361,24 @@ paths:
           schema:
             $ref: '#/definitions/main.ErrorResponse'
       security:
-      - BearerAuth: []
+        - BearerAuth: []
       summary: Update user profile
       tags:
-      - auth
+        - auth
   /auth/register:
     post:
       consumes:
-      - application/json
+        - application/json
       description: Register with email and password
       parameters:
-      - description: User registration data
-        in: body
-        name: user
-        required: true
-        schema:
-          $ref: '#/definitions/main.RegisterRequest'
+        - description: User registration data
+          in: body
+          name: user
+          required: true
+          schema:
+            $ref: '#/definitions/main.RegisterRequest'
       produces:
-      - application/json
+        - application/json
       responses:
         "201":
           description: Created
@@ -394,21 +394,21 @@ paths:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Register a new user
       tags:
-      - auth
+        - auth
   /auth/reset-password:
     post:
       consumes:
-      - application/json
+        - application/json
       description: Send password reset token for email
       parameters:
-      - description: Reset password request
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/main.ResetPasswordRequest'
+        - description: Reset password request
+          in: body
+          name: request
+          required: true
+          schema:
+            $ref: '#/definitions/main.ResetPasswordRequest'
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -428,20 +428,20 @@ paths:
             type: object
       summary: Request password reset
       tags:
-      - auth
+        - auth
   /game/{slug}:
     get:
       consumes:
-      - application/json
+        - application/json
       description: Returns the current state of a game
       parameters:
-      - description: Game slug identifier
-        in: path
-        name: slug
-        required: true
-        type: string
+        - description: Game slug identifier
+          in: path
+          name: slug
+          required: true
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -453,25 +453,25 @@ paths:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Get game state
       tags:
-      - game
+        - game
   /game/{slug}/{turn}:
     get:
       consumes:
-      - application/json
+        - application/json
       description: Returns the state of a game at a specific turn
       parameters:
-      - description: Game slug identifier
-        in: path
-        name: slug
-        required: true
-        type: string
-      - description: Turn number
-        in: path
-        name: turn
-        required: true
-        type: integer
+        - description: Game slug identifier
+          in: path
+          name: slug
+          required: true
+          type: string
+        - description: Turn number
+          in: path
+          name: turn
+          required: true
+          type: integer
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -483,20 +483,20 @@ paths:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Get specific turn
       tags:
-      - game
+        - game
   /game/{slug}/join:
     post:
       consumes:
-      - application/json
+        - application/json
       description: Join a game that is waiting for a second player (as black player)
       parameters:
-      - description: Game slug identifier
-        in: path
-        name: slug
-        required: true
-        type: string
+        - description: Game slug identifier
+          in: path
+          name: slug
+          required: true
+          type: string
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -516,26 +516,26 @@ paths:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Join a waiting game
       tags:
-      - game
+        - game
   /game/{slug}/move:
     post:
       consumes:
-      - application/json
+        - application/json
       description: Submit a move for a specific game
       parameters:
-      - description: Game slug identifier
-        in: path
-        name: slug
-        required: true
-        type: string
-      - description: Move details
-        in: body
-        name: move
-        required: true
-        schema:
-          $ref: '#/definitions/main.MoveRequest'
+        - description: Game slug identifier
+          in: path
+          name: slug
+          required: true
+          type: string
+        - description: Move details
+          in: body
+          name: move
+          required: true
+          schema:
+            $ref: '#/definitions/main.MoveRequest'
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -551,20 +551,20 @@ paths:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Make a move in a game
       tags:
-      - game
+        - game
   /game/new:
     get:
       consumes:
-      - application/json
+        - application/json
       description: Creates a new Tak game with the specified board size
       parameters:
-      - description: Game configuration
-        in: body
-        name: game
-        schema:
-          $ref: '#/definitions/main.CreateGameRequest'
+        - description: Game configuration
+          in: body
+          name: game
+          schema:
+            $ref: '#/definitions/main.CreateGameRequest'
       produces:
-      - application/json
+        - application/json
       responses:
         "307":
           description: Redirect to game URL
@@ -580,19 +580,19 @@ paths:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Create a new game
       tags:
-      - game
+        - game
     post:
       consumes:
-      - application/json
+        - application/json
       description: Creates a new Tak game with the specified board size
       parameters:
-      - description: Game configuration
-        in: body
-        name: game
-        schema:
-          $ref: '#/definitions/main.CreateGameRequest'
+        - description: Game configuration
+          in: body
+          name: game
+          schema:
+            $ref: '#/definitions/main.CreateGameRequest'
       produces:
-      - application/json
+        - application/json
       responses:
         "307":
           description: Redirect to game URL
@@ -608,14 +608,14 @@ paths:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Create a new game
       tags:
-      - game
+        - game
   /healthz:
     get:
       consumes:
-      - application/json
+        - application/json
       description: Returns service health status
       produces:
-      - application/json
+        - application/json
       responses:
         "200":
           description: OK
@@ -623,7 +623,7 @@ paths:
             $ref: '#/definitions/main.HealthResponse'
       summary: Health check
       tags:
-      - health
+        - health
 securityDefinitions:
   BearerAuth:
     description: 'JWT token in format: Bearer {token}'

--- a/game.go
+++ b/game.go
@@ -433,6 +433,57 @@ func ParsePTN(ptn []byte) (*Game, error) {
 	return ret, nil
 }
 
+// turnLabelRegex matches a PTN turn number with an optional single-letter
+// branch suffix (e.g. "1", "1a", "12b").
+var turnLabelRegex = regexp.MustCompile(`^(\d+)([a-z])?$`)
+
+// parseTurnLabel splits a PTN turn label into its numeric and optional
+// branch components. Returns ok=false for anything that isn't a valid
+// label.
+func parseTurnLabel(label string) (int64, string, bool) {
+	m := turnLabelRegex.FindStringSubmatch(label)
+	if m == nil {
+		return 0, "", false
+	}
+	n, err := strconv.ParseInt(m[1], 10, 64)
+	if err != nil {
+		return 0, "", false
+	}
+	return n, m[2], true
+}
+
+// TurnsInBranch returns every turn that belongs to the named branch
+// (use empty string for the main line). Turns are returned in the order
+// they appear in g.Turns; ordering within a branch follows the input
+// PTN.
+func (g *Game) TurnsInBranch(branch string) []*Turn {
+	out := make([]*Turn, 0)
+	for _, t := range g.Turns {
+		if t == nil {
+			continue
+		}
+		if t.Branch == branch {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// Branches returns the set of distinct branch labels present in g.Turns
+// (excluding the main line's empty label) in first-appearance order.
+func (g *Game) Branches() []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, t := range g.Turns {
+		if t == nil || t.Branch == "" || seen[t.Branch] {
+			continue
+		}
+		seen[t.Branch] = true
+		out = append(out, t.Branch)
+	}
+	return out
+}
+
 func parseTag(line string) (*Tag, error) {
 	var tag *Tag
 
@@ -467,18 +518,14 @@ func parseTurn(line string) (*Turn, error) {
 			return turn, fmt.Errorf("line does not have correct number of parts: %+v", fields)
 		}
 
-		// TODO(#40): Support branches. Right now we discard things that are not ints.
-		numberVal := fields[0]
-		numberVal = strings.TrimRight(numberVal, ".")
-		if regexp.MustCompile(`\D+`).MatchString(numberVal) {
-			log.Warnw("not a number, ignoring line", "number", numberVal)
+		numberVal := strings.TrimRight(fields[0], ".")
+		num, branch, ok := parseTurnLabel(numberVal)
+		if !ok {
+			log.Warnw("not a turn label, ignoring line", "number", numberVal)
 			return nil, nil
 		}
-		num, err := strconv.ParseInt(numberVal, 10, 64)
-		if err != nil {
-			return nil, err
-		}
 		turn.Number = num
+		turn.Branch = branch
 
 		p1, err := NewMove(fields[1])
 		if err != nil {

--- a/turn.go
+++ b/turn.go
@@ -9,13 +9,16 @@ type Turn struct {
 	Second  *Move
 	Result  string
 	Comment string
+	// Branch is the optional PTN branch label appended to the turn
+	// number (e.g. `1a.` -> "a"). Main-line turns leave it empty.
+	Branch string
 }
 
 // Text returns a PTN formated string of the turn.
 func (t *Turn) Text() string {
 	var move string
 	if t.First != nil && t.Second != nil {
-		move = fmt.Sprintf("%d. %s %s", t.Number, t.First.Text, t.Second.Text)
+		move = fmt.Sprintf("%d%s. %s %s", t.Number, t.Branch, t.First.Text, t.Second.Text)
 	}
 
 	if t.Comment != "" {


### PR DESCRIPTION
Closes #40.

PTN supports alternate analysis lines via a single-letter branch suffix on the turn number (`1a.`, `2a.`, ...). The parser previously silently dropped anything that wasn't a pure integer; this PR pulls the optional letter into a new `Turn.Branch` field, makes `Turn.Text()` emit it back, and adds `Game.TurnsInBranch` / `Game.Branches` helpers so callers can iterate a specific line.

This is the parsing/representation layer only - replaying branches as separate board states is a larger follow-up that any branch-aware analysis can build on top of this.