### PR TITLE
ci: stop swagger/yaml-json reformat loop and quiet lint

### DIFF
--- a/.github/workflows/yaml-json.yml
+++ b/.github/workflows/yaml-json.yml
@@ -29,21 +29,27 @@ jobs:
         uses: dcarbone/install-yq-action@v1.3.1
       - name: Format YAML files with yq
         run: |
-          # Format YAML in place. Skip vendor and node_modules in case they appear later.
+          # Format YAML in place. Skip generated swagger output (swag's
+          # formatting fights yq's, producing an infinite reformat loop
+          # between this workflow and Update Swagger Documentation) plus
+          # vendor and node_modules in case they appear later.
           find . \( -name "*.yml" -o -name "*.yaml" \) \
             -not -path "./vendor/*" \
             -not -path "./node_modules/*" \
-            -not -path "./.git/*" | while read -r file; do
+            -not -path "./.git/*" \
+            -not -path "./cmd/server/docs/*" | while read -r file; do
             echo "Formatting $file"
             yq -iP '.' "$file"
           done
       - name: Format JSON files with yq
         run: |
           # yq formats JSON with -o=json. go.sum is text, not JSON, so glob only *.json.
+          # Skip generated swagger output for the same reason as above.
           find . -name "*.json" \
             -not -path "./vendor/*" \
             -not -path "./node_modules/*" \
-            -not -path "./.git/*" | while read -r file; do
+            -not -path "./.git/*" \
+            -not -path "./cmd/server/docs/*" | while read -r file; do
             echo "Formatting $file"
             yq -iP -o=json '.' "$file"
           done

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,8 +8,8 @@ linters:
     staticcheck:
       checks:
         - all
-        - -QF1003  # tagged-switch suggestion is a style nit, not a bug
-        - -ST1000  # don't require a package comment in every file
+        - -QF1003 # tagged-switch suggestion is a style nit, not a bug
+        - -ST1000 # don't require a package comment in every file
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,15 @@
+version: "2"
+linters:
+  settings:
+    goconst:
+      min-occurrences: 6
+      ignore-string-values:
+        - ^(error|message|local|waiting|invalid request body|database error|bad connection to db|human)$
+    staticcheck:
+      checks:
+        - all
+        - -QF1003  # tagged-switch suggestion is a style nit, not a bug
+        - -ST1000  # don't require a package comment in every file
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/cmd/server/models.go
+++ b/cmd/server/models.go
@@ -6,7 +6,7 @@ import (
 	"gorm.io/gorm"
 )
 
-// Standard API response types
+// ErrorResponse is the standard error payload returned by API handlers.
 type ErrorResponse struct {
 	Error string `json:"error" example:"Something went wrong"`
 }


### PR DESCRIPTION
Two workflows have been fighting each other on every merge:

- **Update Swagger Documentation** runs on push to main, calls `swag init`, and commits `cmd/server/docs/swagger.{yaml,json}` in swag's emitter style.
- **yaml-json** runs on pull_request, calls `yq -iP` on every YAML/JSON file, and commits the reformatted output (different indentation, alphabetised JSON keys).

Each merge produced one of each commit. Exclude `cmd/server/docs/` from the yq formatter so generated artifacts keep swag's shape.

Also adds a minimal `.golangci.yml` to quiet pre-existing `goconst`/`staticcheck` noise (most of those strings are JSON keys or enum-style identifiers - bumping `min-occurrences` and ignoring a small list avoids touching ~50 call sites), and fixes the one ST1021 doc comment the linter flagged.