### PR TITLE
feat: release gotak CLI via goreleaser + homebrew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+on:
+  schedule:
+    # Run daily at midnight UTC; cuts a release only if there are unreleased
+    # feat:/fix: commits since the last tag.
+    - cron: 0 0 * * *
+  workflow_dispatch: # Manual trigger
+permissions:
+  contents: write
+  packages: write
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # full history for semantic versioning
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: Determine next version
+        id: versioning
+        if: github.event_name != 'push' || !startsWith(github.ref, 'refs/tags/')
+        uses: PaulHatch/semantic-version@v6.0.2
+        with:
+          tag_prefix: v
+          major_pattern: 'BREAKING CHANGE:'
+          minor_pattern: 'feat:'
+          version_format: ${major}.${minor}.${patch}
+      - name: Set version for tag push
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        run: |
+          tag_name="${GITHUB_REF#refs/tags/}"
+          echo "version_tag=$tag_name" >> $GITHUB_OUTPUT
+          echo "version=$tag_name" >> $GITHUB_OUTPUT
+      - name: Create and push tag
+        if: github.event_name != 'push' && steps.versioning.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag ${{ steps.versioning.outputs.version_tag }}
+          git push origin ${{ steps.versioning.outputs.version_tag }}
+      - name: Run GoReleaser
+        if: steps.versioning.outputs.changed == 'true' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: ~> v2
+          args: release --clean
+        env:
+          # GH_PAT is needed to push the cask update to icco/homebrew-tap;
+          # the default GITHUB_TOKEN can only write to this repo.
+          GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,66 @@
+# GoReleaser configuration for gotak.
+# https://goreleaser.com
+version: 2
+project_name: gotak
+builds:
+  - id: gotak
+    main: ./cmd/gotak
+    binary: gotak
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.Version={{.Version}}
+    env:
+      - CGO_ENABLED=0
+archives:
+  - id: default
+    files:
+      - README.md
+      - LICENSE
+checksum:
+  name_template: checksums.txt
+snapshot:
+  version_template: '{{ .Tag }}-next'
+changelog:
+  use: git
+  sort: asc
+  groups:
+    - title: Features
+      regexp: '^feat:'
+      order: 0
+    - title: Bug Fixes
+      regexp: '^fix:'
+      order: 1
+    - title: Other Changes
+      order: 999
+homebrew_casks:
+  - name: gotak
+    directory: Casks
+    repository:
+      owner: icco
+      name: homebrew-tap
+    homepage: https://github.com/icco/gotak
+    description: A CLI client for the Tak board-game server
+    license: MIT
+    binaries:
+      - gotak
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/gotak"]
+          end
+release:
+  github:
+    owner: icco
+    name: gotak
+  mode: replace
+  footer: |
+    ---
+    **Full Changelog**: https://github.com/icco/gotak/compare/{{ .PreviousTag }}...{{ .Tag }}

--- a/cmd/gotak/main.go
+++ b/cmd/gotak/main.go
@@ -19,11 +19,14 @@ import (
 	"github.com/icco/gotak"
 )
 
+// Version is overridden at build time by goreleaser via -ldflags.
+var Version = "dev"
+
 func getVersion() string {
 	if tag := os.Getenv("GIT_TAG"); tag != "" {
 		return tag
 	}
-	return "dev"
+	return Version
 }
 
 // Key bindings used across screens.


### PR DESCRIPTION
Mirrors the release setup from [icco/etu](https://github.com/icco/etu):

- `.goreleaser.yaml` produces darwin/linux/windows × amd64/arm64 archives and a homebrew cask in `icco/homebrew-tap`.
- `.github/workflows/release.yml` runs daily; it tags a new semver if there are unreleased `feat:`/`fix:` commits, then invokes goreleaser. Also dispatchable manually.
- `cmd/gotak/main.go` exposes a `Version` ldflag-overridable var so the goreleaser build stamps the actual tag into the User-Agent. `$GIT_TAG` still wins for Docker.

Needs the `GH_PAT` secret to exist on the repo so goreleaser can push the cask update; the workflow falls back to `GITHUB_TOKEN` (which can't cross-repo write) if the PAT isn't set.