### PR TITLE
feat: add replay and position endpoints

### DIFF
--- a/cmd/server/docs/docs.go
+++ b/cmd/server/docs/docs.go
@@ -596,7 +596,7 @@ const docTemplate = `{
         },
         "/game/{slug}/position/{turn}": {
             "get": {
-                "description": "Replays moves up to and including the requested turn number\nand returns the resulting board state. Turn 0 returns the\nstarting position.",
+                "description": "Replays the game forward until it has applied every move\nof every turn with Number \u003c= turn, then returns the\nresulting board. turn=0 yields the starting (empty)\nposition; turn beyond the final turn yields the final\nposition.",
                 "consumes": [
                     "application/json"
                 ],
@@ -606,7 +606,7 @@ const docTemplate = `{
                 "tags": [
                     "game"
                 ],
-                "summary": "Get board state at a specific turn",
+                "summary": "Get board state after N complete turns",
                 "parameters": [
                     {
                         "type": "string",
@@ -617,7 +617,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "description": "Turn number (0 = empty board)",
+                        "description": "Turn number (0 = starting position)",
                         "name": "turn",
                         "in": "path",
                         "required": true
@@ -653,7 +653,7 @@ const docTemplate = `{
         },
         "/game/{slug}/replay": {
             "get": {
-                "description": "Returns an ordered list of every move in the game along with\nthe board state after each move, so a client can step through\nwithout making per-turn API calls.",
+                "description": "Returns an ordered list of every half-turn played in the\ngame, along with the board state after each one, so a\nclient can step through without making per-turn requests.",
                 "consumes": [
                     "application/json"
                 ],

--- a/cmd/server/docs/docs.go
+++ b/cmd/server/docs/docs.go
@@ -594,6 +594,107 @@ const docTemplate = `{
                 }
             }
         },
+        "/game/{slug}/position/{turn}": {
+            "get": {
+                "description": "Replays moves up to and including the requested turn number\nand returns the resulting board state. Turn 0 returns the\nstarting position.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "game"
+                ],
+                "summary": "Get board state at a specific turn",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Game slug identifier",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Turn number (0 = empty board)",
+                        "name": "turn",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/main.PositionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/game/{slug}/replay": {
+            "get": {
+                "description": "Returns an ordered list of every move in the game along with\nthe board state after each move, so a client can step through\nwithout making per-turn API calls.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "game"
+                ],
+                "summary": "Get full game replay",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Game slug identifier",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/main.ReplayResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/game/{slug}/{turn}": {
             "get": {
                 "description": "Returns the state of a game at a specific turn",
@@ -888,6 +989,29 @@ const docTemplate = `{
                 }
             }
         },
+        "main.PositionResponse": {
+            "type": "object",
+            "properties": {
+                "board": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/gotak.Stone"
+                        }
+                    }
+                },
+                "size": {
+                    "type": "integer"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "turn": {
+                    "type": "integer"
+                }
+            }
+        },
         "main.RegisterRequest": {
             "type": "object",
             "properties": {
@@ -902,6 +1026,46 @@ const docTemplate = `{
                 "password": {
                     "type": "string",
                     "example": "secretpassword"
+                }
+            }
+        },
+        "main.ReplayResponse": {
+            "type": "object",
+            "properties": {
+                "size": {
+                    "type": "integer"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "steps": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/main.ReplayStep"
+                    }
+                }
+            }
+        },
+        "main.ReplayStep": {
+            "type": "object",
+            "properties": {
+                "board": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/gotak.Stone"
+                        }
+                    }
+                },
+                "move": {
+                    "type": "string"
+                },
+                "player": {
+                    "type": "integer"
+                },
+                "turn": {
+                    "type": "integer"
                 }
             }
         },

--- a/cmd/server/docs/swagger.json
+++ b/cmd/server/docs/swagger.json
@@ -588,6 +588,107 @@
                 }
             }
         },
+        "/game/{slug}/position/{turn}": {
+            "get": {
+                "description": "Replays moves up to and including the requested turn number\nand returns the resulting board state. Turn 0 returns the\nstarting position.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "game"
+                ],
+                "summary": "Get board state at a specific turn",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Game slug identifier",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Turn number (0 = empty board)",
+                        "name": "turn",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/main.PositionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/game/{slug}/replay": {
+            "get": {
+                "description": "Returns an ordered list of every move in the game along with\nthe board state after each move, so a client can step through\nwithout making per-turn API calls.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "game"
+                ],
+                "summary": "Get full game replay",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Game slug identifier",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/main.ReplayResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/game/{slug}/{turn}": {
             "get": {
                 "description": "Returns the state of a game at a specific turn",
@@ -882,6 +983,29 @@
                 }
             }
         },
+        "main.PositionResponse": {
+            "type": "object",
+            "properties": {
+                "board": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/gotak.Stone"
+                        }
+                    }
+                },
+                "size": {
+                    "type": "integer"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "turn": {
+                    "type": "integer"
+                }
+            }
+        },
         "main.RegisterRequest": {
             "type": "object",
             "properties": {
@@ -896,6 +1020,46 @@
                 "password": {
                     "type": "string",
                     "example": "secretpassword"
+                }
+            }
+        },
+        "main.ReplayResponse": {
+            "type": "object",
+            "properties": {
+                "size": {
+                    "type": "integer"
+                },
+                "slug": {
+                    "type": "string"
+                },
+                "steps": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/main.ReplayStep"
+                    }
+                }
+            }
+        },
+        "main.ReplayStep": {
+            "type": "object",
+            "properties": {
+                "board": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/gotak.Stone"
+                        }
+                    }
+                },
+                "move": {
+                    "type": "string"
+                },
+                "player": {
+                    "type": "integer"
+                },
+                "turn": {
+                    "type": "integer"
                 }
             }
         },

--- a/cmd/server/docs/swagger.json
+++ b/cmd/server/docs/swagger.json
@@ -590,7 +590,7 @@
         },
         "/game/{slug}/position/{turn}": {
             "get": {
-                "description": "Replays moves up to and including the requested turn number\nand returns the resulting board state. Turn 0 returns the\nstarting position.",
+                "description": "Replays the game forward until it has applied every move\nof every turn with Number \u003c= turn, then returns the\nresulting board. turn=0 yields the starting (empty)\nposition; turn beyond the final turn yields the final\nposition.",
                 "consumes": [
                     "application/json"
                 ],
@@ -600,7 +600,7 @@
                 "tags": [
                     "game"
                 ],
-                "summary": "Get board state at a specific turn",
+                "summary": "Get board state after N complete turns",
                 "parameters": [
                     {
                         "type": "string",
@@ -611,7 +611,7 @@
                     },
                     {
                         "type": "integer",
-                        "description": "Turn number (0 = empty board)",
+                        "description": "Turn number (0 = starting position)",
                         "name": "turn",
                         "in": "path",
                         "required": true
@@ -647,7 +647,7 @@
         },
         "/game/{slug}/replay": {
             "get": {
-                "description": "Returns an ordered list of every move in the game along with\nthe board state after each move, so a client can step through\nwithout making per-turn API calls.",
+                "description": "Returns an ordered list of every half-turn played in the\ngame, along with the board state after each one, so a\nclient can step through without making per-turn requests.",
                 "consumes": [
                     "application/json"
                 ],

--- a/cmd/server/docs/swagger.yaml
+++ b/cmd/server/docs/swagger.yaml
@@ -603,16 +603,18 @@ paths:
       consumes:
       - application/json
       description: |-
-        Replays moves up to and including the requested turn number
-        and returns the resulting board state. Turn 0 returns the
-        starting position.
+        Replays the game forward until it has applied every move
+        of every turn with Number <= turn, then returns the
+        resulting board. turn=0 yields the starting (empty)
+        position; turn beyond the final turn yields the final
+        position.
       parameters:
       - description: Game slug identifier
         in: path
         name: slug
         required: true
         type: string
-      - description: Turn number (0 = empty board)
+      - description: Turn number (0 = starting position)
         in: path
         name: turn
         required: true
@@ -636,7 +638,7 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/main.ErrorResponse'
-      summary: Get board state at a specific turn
+      summary: Get board state after N complete turns
       tags:
       - game
   /game/{slug}/replay:
@@ -644,9 +646,9 @@ paths:
       consumes:
       - application/json
       description: |-
-        Returns an ordered list of every move in the game along with
-        the board state after each move, so a client can step through
-        without making per-turn API calls.
+        Returns an ordered list of every half-turn played in the
+        game, along with the board state after each one, so a
+        client can step through without making per-turn requests.
       parameters:
       - description: Game slug identifier
         in: path

--- a/cmd/server/docs/swagger.yaml
+++ b/cmd/server/docs/swagger.yaml
@@ -154,6 +154,21 @@ definitions:
         example: 1
         type: integer
     type: object
+  main.PositionResponse:
+    properties:
+      board:
+        additionalProperties:
+          items:
+            $ref: '#/definitions/gotak.Stone'
+          type: array
+        type: object
+      size:
+        type: integer
+      slug:
+        type: string
+      turn:
+        type: integer
+    type: object
   main.RegisterRequest:
     properties:
       email:
@@ -165,6 +180,32 @@ definitions:
       password:
         example: secretpassword
         type: string
+    type: object
+  main.ReplayResponse:
+    properties:
+      size:
+        type: integer
+      slug:
+        type: string
+      steps:
+        items:
+          $ref: '#/definitions/main.ReplayStep'
+        type: array
+    type: object
+  main.ReplayStep:
+    properties:
+      board:
+        additionalProperties:
+          items:
+            $ref: '#/definitions/gotak.Stone'
+          type: array
+        type: object
+      move:
+        type: string
+      player:
+        type: integer
+      turn:
+        type: integer
     type: object
   main.ResetPasswordRequest:
     properties:
@@ -555,6 +596,79 @@ paths:
           schema:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Make a move in a game
+      tags:
+      - game
+  /game/{slug}/position/{turn}:
+    get:
+      consumes:
+      - application/json
+      description: |-
+        Replays moves up to and including the requested turn number
+        and returns the resulting board state. Turn 0 returns the
+        starting position.
+      parameters:
+      - description: Game slug identifier
+        in: path
+        name: slug
+        required: true
+        type: string
+      - description: Turn number (0 = empty board)
+        in: path
+        name: turn
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/main.PositionResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+      summary: Get board state at a specific turn
+      tags:
+      - game
+  /game/{slug}/replay:
+    get:
+      consumes:
+      - application/json
+      description: |-
+        Returns an ordered list of every move in the game along with
+        the board state after each move, so a client can step through
+        without making per-turn API calls.
+      parameters:
+      - description: Game slug identifier
+        in: path
+        name: slug
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/main.ReplayResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+      summary: Get full game replay
       tags:
       - game
   /game/new:

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -190,6 +190,8 @@ func buildRouter(opts routerOptions) http.Handler {
 		r.Mount("/auth", AuthRoutes())
 
 		r.Get("/game/{slug}", getGameHandler)
+		r.Get("/game/{slug}/replay", getReplayHandler)
+		r.Get("/game/{slug}/position/{turn}", getPositionHandler)
 		r.Get("/game/{slug}/{turn}", getTurnHandler)
 
 		r.Group(func(r chi.Router) {

--- a/cmd/server/replay.go
+++ b/cmd/server/replay.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/icco/gotak"
+	"github.com/icco/gutil/logging"
+	"go.uber.org/zap"
+)
+
+// ReplayStep is a single recorded position in a game replay. Each turn
+// produces up to two steps (one per player move). The board snapshot is
+// the state after `Move` was applied.
+type ReplayStep struct {
+	Turn   int64                   `json:"turn"`
+	Player int                     `json:"player"`
+	Move   string                  `json:"move"`
+	Board  map[string][]*gotak.Stone `json:"board"`
+}
+
+// ReplayResponse is the payload returned by GET /game/{slug}/replay.
+type ReplayResponse struct {
+	Slug  string       `json:"slug"`
+	Size  int64        `json:"size"`
+	Steps []ReplayStep `json:"steps"`
+}
+
+// PositionResponse is the payload returned by GET /game/{slug}/position/{turn}.
+type PositionResponse struct {
+	Slug  string                    `json:"slug"`
+	Size  int64                     `json:"size"`
+	Turn  int64                     `json:"turn"`
+	Board map[string][]*gotak.Stone `json:"board"`
+}
+
+// @Summary Get full game replay
+// @Description Returns an ordered list of every move in the game along with
+// @Description the board state after each move, so a client can step through
+// @Description without making per-turn API calls.
+// @Tags game
+// @Accept json
+// @Produce json
+// @Param slug path string true "Game slug identifier"
+// @Success 200 {object} ReplayResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /game/{slug}/replay [get]
+func getReplayHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	l := logging.FromContext(ctx)
+
+	db, err := getDB()
+	if err != nil {
+		l.Errorw("could not get db", zap.Error(err))
+		if err := Renderer.JSON(w, http.StatusInternalServerError, ErrorResponse{Error: "bad connection to db"}); err != nil {
+			l.Errorw("failed to render JSON", zap.Error(err))
+		}
+		return
+	}
+
+	slug := ugcPolicy.Sanitize(chi.URLParamFromCtx(ctx, "slug"))
+	game, err := getGame(db, slug)
+	if err != nil {
+		l.Errorw("could not get game", "slug", slug, zap.Error(err))
+		if err := Renderer.JSON(w, http.StatusNotFound, ErrorResponse{Error: "game not found"}); err != nil {
+			l.Errorw("failed to render JSON", zap.Error(err))
+		}
+		return
+	}
+
+	steps, err := buildReplaySteps(game)
+	if err != nil {
+		l.Errorw("could not build replay", "slug", slug, zap.Error(err))
+		if err := Renderer.JSON(w, http.StatusInternalServerError, ErrorResponse{Error: "could not build replay"}); err != nil {
+			l.Errorw("failed to render JSON", zap.Error(err))
+		}
+		return
+	}
+
+	if err := Renderer.JSON(w, http.StatusOK, ReplayResponse{
+		Slug:  slug,
+		Size:  game.Board.Size,
+		Steps: steps,
+	}); err != nil {
+		l.Errorw("failed to render replay response", zap.Error(err))
+	}
+}
+
+// @Summary Get board state at a specific turn
+// @Description Replays moves up to and including the requested turn number
+// @Description and returns the resulting board state. Turn 0 returns the
+// @Description starting position.
+// @Tags game
+// @Accept json
+// @Produce json
+// @Param slug path string true "Game slug identifier"
+// @Param turn path int true "Turn number (0 = empty board)"
+// @Success 200 {object} PositionResponse
+// @Failure 400 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /game/{slug}/position/{turn} [get]
+func getPositionHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	l := logging.FromContext(ctx)
+
+	db, err := getDB()
+	if err != nil {
+		l.Errorw("could not get db", zap.Error(err))
+		if err := Renderer.JSON(w, http.StatusInternalServerError, ErrorResponse{Error: "bad connection to db"}); err != nil {
+			l.Errorw("failed to render JSON", zap.Error(err))
+		}
+		return
+	}
+
+	slug := ugcPolicy.Sanitize(chi.URLParamFromCtx(ctx, "slug"))
+	turnStr := ugcPolicy.Sanitize(chi.URLParamFromCtx(ctx, "turn"))
+	turnNum, err := strconv.ParseInt(turnStr, 10, 64)
+	if err != nil || turnNum < 0 {
+		l.Errorw("invalid turn number", "slug", slug, "turn", turnStr, zap.Error(err))
+		if err := Renderer.JSON(w, http.StatusBadRequest, ErrorResponse{Error: "turn must be a non-negative integer"}); err != nil {
+			l.Errorw("failed to render JSON", zap.Error(err))
+		}
+		return
+	}
+
+	game, err := getGame(db, slug)
+	if err != nil {
+		l.Errorw("could not get game", "slug", slug, zap.Error(err))
+		if err := Renderer.JSON(w, http.StatusNotFound, ErrorResponse{Error: "game not found"}); err != nil {
+			l.Errorw("failed to render JSON", zap.Error(err))
+		}
+		return
+	}
+
+	board, err := boardAtTurn(game, turnNum)
+	if err != nil {
+		l.Errorw("could not replay to turn", "slug", slug, "turn", turnNum, zap.Error(err))
+		if err := Renderer.JSON(w, http.StatusInternalServerError, ErrorResponse{Error: "could not compute position"}); err != nil {
+			l.Errorw("failed to render JSON", zap.Error(err))
+		}
+		return
+	}
+
+	if err := Renderer.JSON(w, http.StatusOK, PositionResponse{
+		Slug:  slug,
+		Size:  game.Board.Size,
+		Turn:  turnNum,
+		Board: board,
+	}); err != nil {
+		l.Errorw("failed to render position response", zap.Error(err))
+	}
+}
+
+// buildReplaySteps walks the game move-by-move, applying each to a fresh
+// board and snapshotting the resulting state.
+func buildReplaySteps(game *gotak.Game) ([]ReplayStep, error) {
+	board := &gotak.Board{Size: game.Board.Size}
+	if err := board.Init(); err != nil {
+		return nil, err
+	}
+
+	steps := make([]ReplayStep, 0, len(game.Turns)*2)
+	for _, turn := range game.Turns {
+		if turn == nil {
+			continue
+		}
+		if turn.First != nil {
+			player := gotak.PlayerWhite
+			if turn.Number == 1 {
+				// Tak rule: the first turn places the opponent's stone.
+				player = gotak.PlayerBlack
+			}
+			if err := board.DoMove(turn.First, player); err != nil {
+				return nil, err
+			}
+			steps = append(steps, ReplayStep{
+				Turn:   turn.Number,
+				Player: gotak.PlayerWhite,
+				Move:   turn.First.Text,
+				Board:  snapshotSquares(board),
+			})
+		}
+		if turn.Second != nil {
+			player := gotak.PlayerBlack
+			if turn.Number == 1 {
+				player = gotak.PlayerWhite
+			}
+			if err := board.DoMove(turn.Second, player); err != nil {
+				return nil, err
+			}
+			steps = append(steps, ReplayStep{
+				Turn:   turn.Number,
+				Player: gotak.PlayerBlack,
+				Move:   turn.Second.Text,
+				Board:  snapshotSquares(board),
+			})
+		}
+	}
+	return steps, nil
+}
+
+// boardAtTurn returns the board state after `turnNum` complete turns have
+// been played. turnNum=0 returns the starting position; turnNum >= len(Turns)
+// returns the final position.
+func boardAtTurn(game *gotak.Game, turnNum int64) (map[string][]*gotak.Stone, error) {
+	board := &gotak.Board{Size: game.Board.Size}
+	if err := board.Init(); err != nil {
+		return nil, err
+	}
+
+	for _, turn := range game.Turns {
+		if turn == nil || turn.Number > turnNum {
+			break
+		}
+		if turn.First != nil {
+			player := gotak.PlayerWhite
+			if turn.Number == 1 {
+				player = gotak.PlayerBlack
+			}
+			if err := board.DoMove(turn.First, player); err != nil {
+				return nil, err
+			}
+		}
+		if turn.Second != nil {
+			player := gotak.PlayerBlack
+			if turn.Number == 1 {
+				player = gotak.PlayerWhite
+			}
+			if err := board.DoMove(turn.Second, player); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return snapshotSquares(board), nil
+}
+
+// snapshotSquares deep-copies a board's square map so callers can keep
+// references that survive further mutation of the original board.
+func snapshotSquares(b *gotak.Board) map[string][]*gotak.Stone {
+	out := make(map[string][]*gotak.Stone, len(b.Squares))
+	for sq, stones := range b.Squares {
+		if len(stones) == 0 {
+			out[sq] = []*gotak.Stone{}
+			continue
+		}
+		copied := make([]*gotak.Stone, len(stones))
+		for i, s := range stones {
+			if s == nil {
+				continue
+			}
+			st := *s
+			copied[i] = &st
+		}
+		out[sq] = copied
+	}
+	return out
+}

--- a/cmd/server/replay.go
+++ b/cmd/server/replay.go
@@ -11,12 +11,12 @@ import (
 )
 
 // ReplayStep is a single recorded position in a game replay. Each turn
-// produces up to two steps (one per player move). The board snapshot is
-// the state after `Move` was applied.
+// produces up to two steps (one per player half-turn). Board is the
+// state immediately after Move was applied.
 type ReplayStep struct {
-	Turn   int64                   `json:"turn"`
-	Player int                     `json:"player"`
-	Move   string                  `json:"move"`
+	Turn   int64                     `json:"turn"`
+	Player int                       `json:"player"`
+	Move   string                    `json:"move"`
 	Board  map[string][]*gotak.Stone `json:"board"`
 }
 
@@ -36,9 +36,9 @@ type PositionResponse struct {
 }
 
 // @Summary Get full game replay
-// @Description Returns an ordered list of every move in the game along with
-// @Description the board state after each move, so a client can step through
-// @Description without making per-turn API calls.
+// @Description Returns an ordered list of every half-turn played in the
+// @Description game, along with the board state after each one, so a
+// @Description client can step through without making per-turn requests.
 // @Tags game
 // @Accept json
 // @Produce json
@@ -51,36 +51,22 @@ func getReplayHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	l := logging.FromContext(ctx)
 
-	db, err := getDB()
-	if err != nil {
-		l.Errorw("could not get db", zap.Error(err))
-		if err := Renderer.JSON(w, http.StatusInternalServerError, ErrorResponse{Error: "bad connection to db"}); err != nil {
-			l.Errorw("failed to render JSON", zap.Error(err))
-		}
-		return
-	}
-
-	slug := ugcPolicy.Sanitize(chi.URLParamFromCtx(ctx, "slug"))
-	game, err := getGame(db, slug)
-	if err != nil {
-		l.Errorw("could not get game", "slug", slug, zap.Error(err))
-		if err := Renderer.JSON(w, http.StatusNotFound, ErrorResponse{Error: "game not found"}); err != nil {
-			l.Errorw("failed to render JSON", zap.Error(err))
-		}
+	game, ok := loadGameForRead(w, r, l)
+	if !ok {
 		return
 	}
 
 	steps, err := buildReplaySteps(game)
 	if err != nil {
-		l.Errorw("could not build replay", "slug", slug, zap.Error(err))
-		if err := Renderer.JSON(w, http.StatusInternalServerError, ErrorResponse{Error: "could not build replay"}); err != nil {
-			l.Errorw("failed to render JSON", zap.Error(err))
+		l.Errorw("could not build replay", "slug", game.Slug, zap.Error(err))
+		if jerr := Renderer.JSON(w, http.StatusInternalServerError, ErrorResponse{Error: "could not build replay"}); jerr != nil {
+			l.Errorw("failed to render JSON", zap.Error(jerr))
 		}
 		return
 	}
 
 	if err := Renderer.JSON(w, http.StatusOK, ReplayResponse{
-		Slug:  slug,
+		Slug:  game.Slug,
 		Size:  game.Board.Size,
 		Steps: steps,
 	}); err != nil {
@@ -88,15 +74,17 @@ func getReplayHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// @Summary Get board state at a specific turn
-// @Description Replays moves up to and including the requested turn number
-// @Description and returns the resulting board state. Turn 0 returns the
-// @Description starting position.
+// @Summary Get board state after N complete turns
+// @Description Replays the game forward until it has applied every move
+// @Description of every turn with Number <= turn, then returns the
+// @Description resulting board. turn=0 yields the starting (empty)
+// @Description position; turn beyond the final turn yields the final
+// @Description position.
 // @Tags game
 // @Accept json
 // @Produce json
 // @Param slug path string true "Game slug identifier"
-// @Param turn path int true "Turn number (0 = empty board)"
+// @Param turn path int true "Turn number (0 = starting position)"
 // @Success 200 {object} PositionResponse
 // @Failure 400 {object} ErrorResponse
 // @Failure 404 {object} ErrorResponse
@@ -106,46 +94,32 @@ func getPositionHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	l := logging.FromContext(ctx)
 
-	db, err := getDB()
-	if err != nil {
-		l.Errorw("could not get db", zap.Error(err))
-		if err := Renderer.JSON(w, http.StatusInternalServerError, ErrorResponse{Error: "bad connection to db"}); err != nil {
-			l.Errorw("failed to render JSON", zap.Error(err))
-		}
-		return
-	}
-
-	slug := ugcPolicy.Sanitize(chi.URLParamFromCtx(ctx, "slug"))
 	turnStr := ugcPolicy.Sanitize(chi.URLParamFromCtx(ctx, "turn"))
 	turnNum, err := strconv.ParseInt(turnStr, 10, 64)
 	if err != nil || turnNum < 0 {
-		l.Errorw("invalid turn number", "slug", slug, "turn", turnStr, zap.Error(err))
-		if err := Renderer.JSON(w, http.StatusBadRequest, ErrorResponse{Error: "turn must be a non-negative integer"}); err != nil {
-			l.Errorw("failed to render JSON", zap.Error(err))
+		l.Warnw("invalid turn number", "turn", turnStr, zap.Error(err))
+		if jerr := Renderer.JSON(w, http.StatusBadRequest, ErrorResponse{Error: "turn must be a non-negative integer"}); jerr != nil {
+			l.Errorw("failed to render JSON", zap.Error(jerr))
 		}
 		return
 	}
 
-	game, err := getGame(db, slug)
-	if err != nil {
-		l.Errorw("could not get game", "slug", slug, zap.Error(err))
-		if err := Renderer.JSON(w, http.StatusNotFound, ErrorResponse{Error: "game not found"}); err != nil {
-			l.Errorw("failed to render JSON", zap.Error(err))
-		}
+	game, ok := loadGameForRead(w, r, l)
+	if !ok {
 		return
 	}
 
 	board, err := boardAtTurn(game, turnNum)
 	if err != nil {
-		l.Errorw("could not replay to turn", "slug", slug, "turn", turnNum, zap.Error(err))
-		if err := Renderer.JSON(w, http.StatusInternalServerError, ErrorResponse{Error: "could not compute position"}); err != nil {
-			l.Errorw("failed to render JSON", zap.Error(err))
+		l.Errorw("could not replay to turn", "slug", game.Slug, "turn", turnNum, zap.Error(err))
+		if jerr := Renderer.JSON(w, http.StatusInternalServerError, ErrorResponse{Error: "could not compute position"}); jerr != nil {
+			l.Errorw("failed to render JSON", zap.Error(jerr))
 		}
 		return
 	}
 
 	if err := Renderer.JSON(w, http.StatusOK, PositionResponse{
-		Slug:  slug,
+		Slug:  game.Slug,
 		Size:  game.Board.Size,
 		Turn:  turnNum,
 		Board: board,
@@ -154,9 +128,41 @@ func getPositionHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// buildReplaySteps walks the game move-by-move, applying each to a fresh
-// board and snapshotting the resulting state.
+// loadGameForRead handles the getDB + getGame boilerplate shared by the
+// read-only game endpoints. It writes the appropriate error response
+// itself; callers should bail when it returns ok=false.
+func loadGameForRead(w http.ResponseWriter, r *http.Request, l *zap.SugaredLogger) (*gotak.Game, bool) {
+	ctx := r.Context()
+	db, err := getDB()
+	if err != nil {
+		l.Errorw("could not get db", zap.Error(err))
+		if jerr := Renderer.JSON(w, http.StatusInternalServerError, ErrorResponse{Error: "bad connection to db"}); jerr != nil {
+			l.Errorw("failed to render JSON", zap.Error(jerr))
+		}
+		return nil, false
+	}
+
+	slug := ugcPolicy.Sanitize(chi.URLParamFromCtx(ctx, "slug"))
+	game, err := getGame(db, slug)
+	if err != nil {
+		l.Errorw("could not get game", "slug", slug, zap.Error(err))
+		if jerr := Renderer.JSON(w, http.StatusNotFound, ErrorResponse{Error: "game not found"}); jerr != nil {
+			l.Errorw("failed to render JSON", zap.Error(jerr))
+		}
+		return nil, false
+	}
+	return game, true
+}
+
+// buildReplaySteps walks the game and applies each half-turn to a fresh
+// board, snapshotting the resulting state into a ReplayStep.
+//
+// We do not reuse game.Board (already populated by getGame's replayMoves
+// call) because we need every intermediate state, not just the final one.
 func buildReplaySteps(game *gotak.Game) ([]ReplayStep, error) {
+	if game == nil || game.Board == nil {
+		return nil, nil
+	}
 	board := &gotak.Board{Size: game.Board.Size}
 	if err := board.Init(); err != nil {
 		return nil, err
@@ -168,12 +174,7 @@ func buildReplaySteps(game *gotak.Game) ([]ReplayStep, error) {
 			continue
 		}
 		if turn.First != nil {
-			player := gotak.PlayerWhite
-			if turn.Number == 1 {
-				// Tak rule: the first turn places the opponent's stone.
-				player = gotak.PlayerBlack
-			}
-			if err := board.DoMove(turn.First, player); err != nil {
+			if err := applyHalfTurn(board, turn, false); err != nil {
 				return nil, err
 			}
 			steps = append(steps, ReplayStep{
@@ -184,11 +185,7 @@ func buildReplaySteps(game *gotak.Game) ([]ReplayStep, error) {
 			})
 		}
 		if turn.Second != nil {
-			player := gotak.PlayerBlack
-			if turn.Number == 1 {
-				player = gotak.PlayerWhite
-			}
-			if err := board.DoMove(turn.Second, player); err != nil {
+			if err := applyHalfTurn(board, turn, true); err != nil {
 				return nil, err
 			}
 			steps = append(steps, ReplayStep{
@@ -202,34 +199,33 @@ func buildReplaySteps(game *gotak.Game) ([]ReplayStep, error) {
 	return steps, nil
 }
 
-// boardAtTurn returns the board state after `turnNum` complete turns have
-// been played. turnNum=0 returns the starting position; turnNum >= len(Turns)
-// returns the final position.
+// boardAtTurn returns the board state after every move of every turn with
+// Number <= turnNum has been applied. turnNum=0 yields the starting
+// position; turnNum beyond the final recorded turn yields the final
+// position.
 func boardAtTurn(game *gotak.Game, turnNum int64) (map[string][]*gotak.Stone, error) {
+	if game == nil || game.Board == nil {
+		return nil, nil
+	}
 	board := &gotak.Board{Size: game.Board.Size}
 	if err := board.Init(); err != nil {
 		return nil, err
 	}
 
 	for _, turn := range game.Turns {
-		if turn == nil || turn.Number > turnNum {
-			break
+		if turn == nil {
+			continue
+		}
+		if turn.Number > turnNum {
+			continue // skip rather than break: don't assume Turns is sorted
 		}
 		if turn.First != nil {
-			player := gotak.PlayerWhite
-			if turn.Number == 1 {
-				player = gotak.PlayerBlack
-			}
-			if err := board.DoMove(turn.First, player); err != nil {
+			if err := applyHalfTurn(board, turn, false); err != nil {
 				return nil, err
 			}
 		}
 		if turn.Second != nil {
-			player := gotak.PlayerBlack
-			if turn.Number == 1 {
-				player = gotak.PlayerWhite
-			}
-			if err := board.DoMove(turn.Second, player); err != nil {
+			if err := applyHalfTurn(board, turn, true); err != nil {
 				return nil, err
 			}
 		}
@@ -237,8 +233,35 @@ func boardAtTurn(game *gotak.Game, turnNum int64) (map[string][]*gotak.Stone, er
 	return snapshotSquares(board), nil
 }
 
-// snapshotSquares deep-copies a board's square map so callers can keep
-// references that survive further mutation of the original board.
+// applyHalfTurn applies one move from a turn to the board with the
+// correct color. The "first" / "second" boolean selects which move;
+// turn 1 inverts the colors because each player places the opponent's
+// stone on the opening turn.
+func applyHalfTurn(b *gotak.Board, turn *gotak.Turn, second bool) error {
+	var mv *gotak.Move
+	var player int
+	if second {
+		mv = turn.Second
+		player = gotak.PlayerBlack
+		if turn.Number == 1 {
+			player = gotak.PlayerWhite
+		}
+	} else {
+		mv = turn.First
+		player = gotak.PlayerWhite
+		if turn.Number == 1 {
+			player = gotak.PlayerBlack
+		}
+	}
+	if mv == nil {
+		return nil
+	}
+	return b.DoMove(mv, player)
+}
+
+// snapshotSquares deep-copies a board's square map so each ReplayStep
+// holds an independent view that won't change as later moves are
+// applied to the live board.
 func snapshotSquares(b *gotak.Board) map[string][]*gotak.Stone {
 	out := make(map[string][]*gotak.Stone, len(b.Squares))
 	for sq, stones := range b.Squares {

--- a/cmd/server/replay_test.go
+++ b/cmd/server/replay_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/icco/gotak"
+)
+
+// playGame builds a game by applying the given (player, moveText) pairs
+// in order.
+func playGame(t *testing.T, size int64, moves []struct {
+	player int
+	move   string
+}) *gotak.Game {
+	t.Helper()
+	g, err := gotak.NewGame(size, 1, "test")
+	if err != nil {
+		t.Fatalf("NewGame: %v", err)
+	}
+	for _, m := range moves {
+		if err := g.DoSingleMove(m.move, m.player); err != nil {
+			t.Fatalf("DoSingleMove(%q, %d): %v", m.move, m.player, err)
+		}
+	}
+	return g
+}
+
+func TestBuildReplaySteps_emptyGame(t *testing.T) {
+	g, err := gotak.NewGame(5, 1, "t")
+	if err != nil {
+		t.Fatal(err)
+	}
+	steps, err := buildReplaySteps(g)
+	if err != nil {
+		t.Fatalf("buildReplaySteps: %v", err)
+	}
+	if len(steps) != 0 {
+		t.Errorf("expected 0 steps, got %d", len(steps))
+	}
+}
+
+func TestBuildReplaySteps_firstTurnInversion(t *testing.T) {
+	// Turn 1: White plays a1, Black plays e5. Per Tak rules each player
+	// places the OPPONENT's stone on turn 1, so a1 ends up black and e5
+	// ends up white.
+	g := playGame(t, 5, []struct {
+		player int
+		move   string
+	}{
+		{gotak.PlayerWhite, "a1"},
+		{gotak.PlayerBlack, "e5"},
+	})
+
+	steps, err := buildReplaySteps(g)
+	if err != nil {
+		t.Fatalf("buildReplaySteps: %v", err)
+	}
+	if len(steps) != 2 {
+		t.Fatalf("expected 2 steps, got %d", len(steps))
+	}
+
+	a1 := steps[0].Board["a1"]
+	if len(a1) != 1 || a1[0].Player != gotak.PlayerBlack {
+		t.Errorf("step 0 a1 = %+v, want single black stone", a1)
+	}
+	e5 := steps[1].Board["e5"]
+	if len(e5) != 1 || e5[0].Player != gotak.PlayerWhite {
+		t.Errorf("step 1 e5 = %+v, want single white stone", e5)
+	}
+
+	if steps[0].Player != gotak.PlayerWhite || steps[0].Move != "a1" {
+		t.Errorf("step 0 metadata = %+v, want White/a1", steps[0])
+	}
+	if steps[1].Player != gotak.PlayerBlack || steps[1].Move != "e5" {
+		t.Errorf("step 1 metadata = %+v, want Black/e5", steps[1])
+	}
+}
+
+func TestBuildReplaySteps_snapshotsAreIndependent(t *testing.T) {
+	// Each snapshot should be a deep copy so mutations to the live board
+	// after step N don't show up in step N's snapshot.
+	g := playGame(t, 5, []struct {
+		player int
+		move   string
+	}{
+		{gotak.PlayerWhite, "a1"},
+		{gotak.PlayerBlack, "e5"},
+		{gotak.PlayerWhite, "b2"},
+	})
+	steps, err := buildReplaySteps(g)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 0 (after move 1) should have a1 occupied but b2 empty.
+	if len(steps[0].Board["a1"]) != 1 {
+		t.Errorf("step 0 a1 should be occupied")
+	}
+	if len(steps[0].Board["b2"]) != 0 {
+		t.Errorf("step 0 b2 should be empty, got %+v", steps[0].Board["b2"])
+	}
+
+	// Step 2 (after b2) should have b2 occupied.
+	if len(steps[2].Board["b2"]) != 1 {
+		t.Errorf("step 2 b2 should be occupied, got %+v", steps[2].Board["b2"])
+	}
+}
+
+func TestBoardAtTurn(t *testing.T) {
+	g := playGame(t, 5, []struct {
+		player int
+		move   string
+	}{
+		{gotak.PlayerWhite, "a1"},
+		{gotak.PlayerBlack, "e5"},
+		{gotak.PlayerWhite, "b2"},
+		{gotak.PlayerBlack, "d4"},
+	})
+
+	// Turn 0: empty board.
+	at0, err := boardAtTurn(g, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for sq, stones := range at0 {
+		if len(stones) != 0 {
+			t.Errorf("turn 0 square %s should be empty, got %+v", sq, stones)
+		}
+	}
+
+	// Turn 1: a1 (black per Tak rule) + e5 (white per Tak rule).
+	at1, err := boardAtTurn(g, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(at1["a1"]) != 1 || at1["a1"][0].Player != gotak.PlayerBlack {
+		t.Errorf("turn 1 a1 = %+v, want black", at1["a1"])
+	}
+	if len(at1["b2"]) != 0 {
+		t.Errorf("turn 1 b2 should still be empty, got %+v", at1["b2"])
+	}
+
+	// Turn 2: a1 + e5 + b2 (white) + d4 (black).
+	at2, err := boardAtTurn(g, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(at2["b2"]) != 1 || at2["b2"][0].Player != gotak.PlayerWhite {
+		t.Errorf("turn 2 b2 = %+v, want white", at2["b2"])
+	}
+	if len(at2["d4"]) != 1 || at2["d4"][0].Player != gotak.PlayerBlack {
+		t.Errorf("turn 2 d4 = %+v, want black", at2["d4"])
+	}
+
+	// Turn way-past-end: same as final state.
+	atBig, err := boardAtTurn(g, 99)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(atBig["d4"]) != 1 {
+		t.Errorf("turn 99 d4 should be occupied (same as final)")
+	}
+}
+
+func TestSnapshotSquares_isDeepCopy(t *testing.T) {
+	g := playGame(t, 5, []struct {
+		player int
+		move   string
+	}{
+		{gotak.PlayerWhite, "a1"},
+	})
+	snap := snapshotSquares(g.Board)
+	g.Board.Squares["a1"][0].Player = -999
+	if snap["a1"][0].Player == -999 {
+		t.Errorf("snapshot was a shallow copy; mutation leaked through")
+	}
+}

--- a/cmd/server/replay_test.go
+++ b/cmd/server/replay_test.go
@@ -6,12 +6,15 @@ import (
 	"github.com/icco/gotak"
 )
 
-// playGame builds a game by applying the given (player, moveText) pairs
-// in order.
-func playGame(t *testing.T, size int64, moves []struct {
+// scriptedMove is one entry in a hand-crafted game used by tests.
+type scriptedMove struct {
 	player int
 	move   string
-}) *gotak.Game {
+}
+
+// playGame builds a game by applying the given (player, move) pairs in
+// order. It fails the test if any move is rejected.
+func playGame(t *testing.T, size int64, moves []scriptedMove) *gotak.Game {
 	t.Helper()
 	g, err := gotak.NewGame(size, 1, "test")
 	if err != nil {
@@ -35,18 +38,24 @@ func TestBuildReplaySteps_emptyGame(t *testing.T) {
 		t.Fatalf("buildReplaySteps: %v", err)
 	}
 	if len(steps) != 0 {
-		t.Errorf("expected 0 steps, got %d", len(steps))
+		t.Errorf("got %d steps, want 0", len(steps))
+	}
+}
+
+func TestBuildReplaySteps_nilGame(t *testing.T) {
+	steps, err := buildReplaySteps(nil)
+	if err != nil {
+		t.Errorf("nil game should return (nil, nil), got err=%v", err)
+	}
+	if steps != nil {
+		t.Errorf("nil game should return (nil, nil), got %d steps", len(steps))
 	}
 }
 
 func TestBuildReplaySteps_firstTurnInversion(t *testing.T) {
-	// Turn 1: White plays a1, Black plays e5. Per Tak rules each player
-	// places the OPPONENT's stone on turn 1, so a1 ends up black and e5
-	// ends up white.
-	g := playGame(t, 5, []struct {
-		player int
-		move   string
-	}{
+	// On turn 1 each player places the opponent's stone: White's a1
+	// lands as a black stone, Black's e5 lands as a white stone.
+	g := playGame(t, 5, []scriptedMove{
 		{gotak.PlayerWhite, "a1"},
 		{gotak.PlayerBlack, "e5"},
 	})
@@ -56,15 +65,13 @@ func TestBuildReplaySteps_firstTurnInversion(t *testing.T) {
 		t.Fatalf("buildReplaySteps: %v", err)
 	}
 	if len(steps) != 2 {
-		t.Fatalf("expected 2 steps, got %d", len(steps))
+		t.Fatalf("got %d steps, want 2", len(steps))
 	}
 
-	a1 := steps[0].Board["a1"]
-	if len(a1) != 1 || a1[0].Player != gotak.PlayerBlack {
+	if a1 := steps[0].Board["a1"]; len(a1) != 1 || a1[0].Player != gotak.PlayerBlack {
 		t.Errorf("step 0 a1 = %+v, want single black stone", a1)
 	}
-	e5 := steps[1].Board["e5"]
-	if len(e5) != 1 || e5[0].Player != gotak.PlayerWhite {
+	if e5 := steps[1].Board["e5"]; len(e5) != 1 || e5[0].Player != gotak.PlayerWhite {
 		t.Errorf("step 1 e5 = %+v, want single white stone", e5)
 	}
 
@@ -77,12 +84,7 @@ func TestBuildReplaySteps_firstTurnInversion(t *testing.T) {
 }
 
 func TestBuildReplaySteps_snapshotsAreIndependent(t *testing.T) {
-	// Each snapshot should be a deep copy so mutations to the live board
-	// after step N don't show up in step N's snapshot.
-	g := playGame(t, 5, []struct {
-		player int
-		move   string
-	}{
+	g := playGame(t, 5, []scriptedMove{
 		{gotak.PlayerWhite, "a1"},
 		{gotak.PlayerBlack, "e5"},
 		{gotak.PlayerWhite, "b2"},
@@ -92,86 +94,175 @@ func TestBuildReplaySteps_snapshotsAreIndependent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Step 0 (after move 1) should have a1 occupied but b2 empty.
+	// Step 0 (after move 1) has a1 set, b2 empty.
 	if len(steps[0].Board["a1"]) != 1 {
 		t.Errorf("step 0 a1 should be occupied")
 	}
 	if len(steps[0].Board["b2"]) != 0 {
 		t.Errorf("step 0 b2 should be empty, got %+v", steps[0].Board["b2"])
 	}
-
-	// Step 2 (after b2) should have b2 occupied.
+	// Step 2 (after b2) has b2 occupied. If step 0's snapshot shared
+	// state with the live board, b2 would already be set here.
 	if len(steps[2].Board["b2"]) != 1 {
 		t.Errorf("step 2 b2 should be occupied, got %+v", steps[2].Board["b2"])
 	}
 }
 
 func TestBoardAtTurn(t *testing.T) {
-	g := playGame(t, 5, []struct {
-		player int
-		move   string
-	}{
+	g := playGame(t, 5, []scriptedMove{
 		{gotak.PlayerWhite, "a1"},
 		{gotak.PlayerBlack, "e5"},
 		{gotak.PlayerWhite, "b2"},
 		{gotak.PlayerBlack, "d4"},
 	})
 
-	// Turn 0: empty board.
-	at0, err := boardAtTurn(g, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	for sq, stones := range at0 {
-		if len(stones) != 0 {
-			t.Errorf("turn 0 square %s should be empty, got %+v", sq, stones)
-		}
+	cases := []struct {
+		name string
+		turn int64
+		// occupied lists (square, expectedPlayer) pairs; everything else
+		// should be empty.
+		occupied map[string]int
+	}{
+		{
+			name:     "turn 0: empty board",
+			turn:     0,
+			occupied: map[string]int{},
+		},
+		{
+			name: "turn 1: opening placements (colors inverted)",
+			turn: 1,
+			occupied: map[string]int{
+				"a1": gotak.PlayerBlack,
+				"e5": gotak.PlayerWhite,
+			},
+		},
+		{
+			name: "turn 2: own-color placements",
+			turn: 2,
+			occupied: map[string]int{
+				"a1": gotak.PlayerBlack,
+				"e5": gotak.PlayerWhite,
+				"b2": gotak.PlayerWhite,
+				"d4": gotak.PlayerBlack,
+			},
+		},
+		{
+			name: "turn way past end: same as final",
+			turn: 99,
+			occupied: map[string]int{
+				"a1": gotak.PlayerBlack,
+				"e5": gotak.PlayerWhite,
+				"b2": gotak.PlayerWhite,
+				"d4": gotak.PlayerBlack,
+			},
+		},
 	}
 
-	// Turn 1: a1 (black per Tak rule) + e5 (white per Tak rule).
-	at1, err := boardAtTurn(g, 1)
-	if err != nil {
-		t.Fatal(err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			board, err := boardAtTurn(g, tc.turn)
+			if err != nil {
+				t.Fatalf("boardAtTurn(%d): %v", tc.turn, err)
+			}
+			for sq, stones := range board {
+				want, isOccupied := tc.occupied[sq]
+				if !isOccupied {
+					if len(stones) != 0 {
+						t.Errorf("square %s should be empty, got %+v", sq, stones)
+					}
+					continue
+				}
+				if len(stones) != 1 {
+					t.Errorf("square %s should have one stone, got %+v", sq, stones)
+					continue
+				}
+				if stones[0].Player != want {
+					t.Errorf("square %s should be player %d, got %d", sq, want, stones[0].Player)
+				}
+			}
+		})
 	}
-	if len(at1["a1"]) != 1 || at1["a1"][0].Player != gotak.PlayerBlack {
-		t.Errorf("turn 1 a1 = %+v, want black", at1["a1"])
-	}
-	if len(at1["b2"]) != 0 {
-		t.Errorf("turn 1 b2 should still be empty, got %+v", at1["b2"])
-	}
+}
 
-	// Turn 2: a1 + e5 + b2 (white) + d4 (black).
-	at2, err := boardAtTurn(g, 2)
+func TestBoardAtTurn_nilGame(t *testing.T) {
+	board, err := boardAtTurn(nil, 0)
 	if err != nil {
-		t.Fatal(err)
+		t.Errorf("nil game should return (nil, nil), got err=%v", err)
 	}
-	if len(at2["b2"]) != 1 || at2["b2"][0].Player != gotak.PlayerWhite {
-		t.Errorf("turn 2 b2 = %+v, want white", at2["b2"])
-	}
-	if len(at2["d4"]) != 1 || at2["d4"][0].Player != gotak.PlayerBlack {
-		t.Errorf("turn 2 d4 = %+v, want black", at2["d4"])
-	}
-
-	// Turn way-past-end: same as final state.
-	atBig, err := boardAtTurn(g, 99)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(atBig["d4"]) != 1 {
-		t.Errorf("turn 99 d4 should be occupied (same as final)")
+	if board != nil {
+		t.Errorf("nil game should return (nil, nil), got %d squares", len(board))
 	}
 }
 
 func TestSnapshotSquares_isDeepCopy(t *testing.T) {
-	g := playGame(t, 5, []struct {
-		player int
-		move   string
-	}{
+	g := playGame(t, 5, []scriptedMove{
 		{gotak.PlayerWhite, "a1"},
 	})
 	snap := snapshotSquares(g.Board)
 	g.Board.Squares["a1"][0].Player = -999
 	if snap["a1"][0].Player == -999 {
 		t.Errorf("snapshot was a shallow copy; mutation leaked through")
+	}
+}
+
+func TestApplyHalfTurn_turnOneInversion(t *testing.T) {
+	b := &gotak.Board{Size: 5}
+	if err := b.Init(); err != nil {
+		t.Fatal(err)
+	}
+	turn := &gotak.Turn{
+		Number: 1,
+		First:  &gotak.Move{Stone: gotak.StoneFlat, Square: "a1", Text: "a1"},
+		Second: &gotak.Move{Stone: gotak.StoneFlat, Square: "e5", Text: "e5"},
+	}
+	if err := applyHalfTurn(b, turn, false); err != nil {
+		t.Fatalf("apply first: %v", err)
+	}
+	if err := applyHalfTurn(b, turn, true); err != nil {
+		t.Fatalf("apply second: %v", err)
+	}
+	if b.Squares["a1"][0].Player != gotak.PlayerBlack {
+		t.Errorf("turn-1 First should place black stone, got %+v", b.Squares["a1"])
+	}
+	if b.Squares["e5"][0].Player != gotak.PlayerWhite {
+		t.Errorf("turn-1 Second should place white stone, got %+v", b.Squares["e5"])
+	}
+}
+
+func TestApplyHalfTurn_normalTurn(t *testing.T) {
+	b := &gotak.Board{Size: 5}
+	if err := b.Init(); err != nil {
+		t.Fatal(err)
+	}
+	turn := &gotak.Turn{
+		Number: 4,
+		First:  &gotak.Move{Stone: gotak.StoneFlat, Square: "c3", Text: "c3"},
+		Second: &gotak.Move{Stone: gotak.StoneFlat, Square: "d4", Text: "d4"},
+	}
+	if err := applyHalfTurn(b, turn, false); err != nil {
+		t.Fatalf("apply first: %v", err)
+	}
+	if err := applyHalfTurn(b, turn, true); err != nil {
+		t.Fatalf("apply second: %v", err)
+	}
+	if b.Squares["c3"][0].Player != gotak.PlayerWhite {
+		t.Errorf("First should place white stone on non-opening turn")
+	}
+	if b.Squares["d4"][0].Player != gotak.PlayerBlack {
+		t.Errorf("Second should place black stone on non-opening turn")
+	}
+}
+
+func TestApplyHalfTurn_missingMoveIsNoop(t *testing.T) {
+	b := &gotak.Board{Size: 5}
+	if err := b.Init(); err != nil {
+		t.Fatal(err)
+	}
+	turn := &gotak.Turn{Number: 2} // no First, no Second
+	if err := applyHalfTurn(b, turn, false); err != nil {
+		t.Errorf("missing First should be a no-op, got %v", err)
+	}
+	if err := applyHalfTurn(b, turn, true); err != nil {
+		t.Errorf("missing Second should be a no-op, got %v", err)
 	}
 }


### PR DESCRIPTION
Refs #45. Two read-only endpoints for stepping through a game without per-turn calls:

- `GET /game/{slug}/replay` — every move plus a board snapshot after each.
- `GET /game/{slug}/position/{turn}` — board state after N complete turns (`turn=0` = empty).

Websockets, spectator chat, and share links stay out of scope.