### PR TITLE
feat: add per-move analysis endpoint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,7 @@ linters:
     goconst:
       min-occurrences: 6
       ignore-string-values:
-        - ^(error|message|local|waiting|invalid request body|database error|bad connection to db|human)$
+        - ^(error|message|local|waiting|invalid request body|database error|bad connection to db|human|beginner|intermediate|advanced|expert|aggressive|defensive|balanced)$
     staticcheck:
       checks:
         - all

--- a/cmd/server/analyze.go
+++ b/cmd/server/analyze.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/icco/gotak"
+	"github.com/icco/gotak/ai"
+	"github.com/icco/gutil/logging"
+	"go.uber.org/zap"
+)
+
+// AnalyzeRequest configures the analysis engine. All fields are optional;
+// sensible defaults are used.
+type AnalyzeRequest struct {
+	Level     string        `json:"level"`
+	Style     string        `json:"style"`
+	TimeLimit time.Duration `json:"time_limit"`
+}
+
+// PlyAnalysis is the result for a single half-turn.
+type PlyAnalysis struct {
+	Turn   int64  `json:"turn"`
+	Player int    `json:"player"`
+	Played string `json:"played"`
+	Best   string `json:"best"`
+	Agreed bool   `json:"agreed"`
+	// Error captures why the engine couldn't evaluate this ply, if any.
+	// When non-empty Best and Agreed are meaningless.
+	Error string `json:"error,omitempty"`
+}
+
+// AnalyzeResponse is the payload returned by POST /analyze/game/{slug}.
+type AnalyzeResponse struct {
+	Slug   string        `json:"slug"`
+	Size   int64         `json:"size"`
+	Level  string        `json:"level"`
+	Plies  []PlyAnalysis `json:"plies"`
+	Played int           `json:"played"`
+	Agreed int           `json:"agreed"`
+}
+
+// @Summary Analyze a game move-by-move
+// @Description For each ply, asks the AI engine what it would play in that
+// @Description position and records whether the player's move matches. A
+// @Description rough "blunder detector"; intended as a starting point for
+// @Description deeper analysis features.
+// @Tags analysis
+// @Accept json
+// @Produce json
+// @Param slug path string true "Game slug identifier"
+// @Param request body AnalyzeRequest false "Engine config (optional)"
+// @Success 200 {object} AnalyzeResponse
+// @Failure 400 {object} ErrorResponse
+// @Failure 404 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /analyze/game/{slug} [post]
+func postAnalyzeHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	l := logging.FromContext(ctx)
+
+	db, err := getDB()
+	if err != nil {
+		l.Errorw("could not get db", zap.Error(err))
+		if err := Renderer.JSON(w, http.StatusInternalServerError, ErrorResponse{Error: "bad connection to db"}); err != nil {
+			l.Errorw("failed to render JSON", zap.Error(err))
+		}
+		return
+	}
+
+	slug := ugcPolicy.Sanitize(chi.URLParamFromCtx(ctx, "slug"))
+	game, err := getGame(db, slug)
+	if err != nil {
+		l.Errorw("could not get game", "slug", slug, zap.Error(err))
+		if err := Renderer.JSON(w, http.StatusNotFound, ErrorResponse{Error: "game not found"}); err != nil {
+			l.Errorw("failed to render JSON", zap.Error(err))
+		}
+		return
+	}
+
+	// Empty body is OK; defaults apply.
+	var req AnalyzeRequest
+	if r.Body != nil {
+		_ = json.NewDecoder(r.Body).Decode(&req)
+	}
+	cfg := analyzeConfigFromRequest(req)
+
+	plies := analyzeGame(ctx, &ai.TakticianEngine{}, game, cfg)
+	resp := AnalyzeResponse{
+		Slug:   slug,
+		Size:   game.Board.Size,
+		Level:  string(req.Level),
+		Plies:  plies,
+		Played: len(plies),
+	}
+	for _, p := range plies {
+		if p.Agreed {
+			resp.Agreed++
+		}
+	}
+	if resp.Level == "" {
+		resp.Level = "advanced"
+	}
+
+	if err := Renderer.JSON(w, http.StatusOK, resp); err != nil {
+		l.Errorw("failed to render analyze response", zap.Error(err))
+	}
+}
+
+// analyzeConfigFromRequest maps the wire-level request to an ai.AIConfig,
+// applying defaults aimed at making the analysis stronger than typical
+// gameplay (we'd rather flag a real blunder than miss one).
+func analyzeConfigFromRequest(req AnalyzeRequest) ai.AIConfig {
+	level := ai.Advanced
+	switch req.Level {
+	case "beginner":
+		level = ai.Beginner
+	case "intermediate":
+		level = ai.Intermediate
+	case "advanced":
+		level = ai.Advanced
+	case "expert":
+		level = ai.Expert
+	}
+
+	style := ai.Balanced
+	switch req.Style {
+	case "aggressive":
+		style = ai.Aggressive
+	case "defensive":
+		style = ai.Defensive
+	}
+
+	timeLimit := 2 * time.Second
+	if req.TimeLimit > 0 {
+		timeLimit = req.TimeLimit
+	}
+	return ai.AIConfig{Level: level, Style: style, TimeLimit: timeLimit}
+}
+
+// analyzeGame walks `g` ply by ply and asks `engine` for the best move at
+// each position. The original game is not mutated.
+func analyzeGame(ctx context.Context, engine ai.Engine, g *gotak.Game, cfg ai.AIConfig) []PlyAnalysis {
+	plies := []PlyAnalysis{}
+	if g == nil || len(g.Turns) == 0 {
+		return plies
+	}
+
+	for turnIdx, turn := range g.Turns {
+		if turn == nil {
+			continue
+		}
+		if turn.First != nil {
+			plies = append(plies, evaluatePly(ctx, engine, g, turnIdx, false, turn.Number, gotak.PlayerWhite, turn.First.Text, cfg))
+		}
+		if turn.Second != nil {
+			plies = append(plies, evaluatePly(ctx, engine, g, turnIdx, true, turn.Number, gotak.PlayerBlack, turn.Second.Text, cfg))
+		}
+	}
+	return plies
+}
+
+func evaluatePly(
+	ctx context.Context,
+	engine ai.Engine,
+	orig *gotak.Game,
+	turnIdx int,
+	second bool,
+	turnNumber int64,
+	player int,
+	played string,
+	cfg ai.AIConfig,
+) PlyAnalysis {
+	out := PlyAnalysis{Turn: turnNumber, Player: player, Played: played}
+
+	pre, err := gameBeforePly(orig, turnIdx, second)
+	if err != nil {
+		out.Error = err.Error()
+		return out
+	}
+
+	best, err := engine.GetMove(ctx, pre, cfg)
+	if err != nil {
+		out.Error = err.Error()
+		return out
+	}
+	out.Best = best
+	out.Agreed = best == played
+	return out
+}
+
+// gameBeforePly returns a fresh *gotak.Game whose Turns slice represents
+// the state of `orig` immediately before the ply identified by
+// (turnIdx, second). If `second` is true, the first move of orig.Turns[turnIdx]
+// is included; otherwise only orig.Turns[0..turnIdx-1] are included.
+//
+// The returned game shares move pointers with the original (the engine
+// reads moves but does not mutate them).
+func gameBeforePly(orig *gotak.Game, turnIdx int, second bool) (*gotak.Game, error) {
+	g, err := gotak.NewGame(orig.Board.Size, orig.ID, orig.Slug)
+	if err != nil {
+		return nil, err
+	}
+	g.Meta = orig.Meta
+
+	for i := 0; i < turnIdx; i++ {
+		t := orig.Turns[i]
+		if t == nil {
+			continue
+		}
+		g.Turns = append(g.Turns, &gotak.Turn{
+			Number: t.Number,
+			First:  t.First,
+			Second: t.Second,
+		})
+	}
+	if second && turnIdx < len(orig.Turns) && orig.Turns[turnIdx] != nil {
+		t := orig.Turns[turnIdx]
+		g.Turns = append(g.Turns, &gotak.Turn{
+			Number: t.Number,
+			First:  t.First,
+		})
+	}
+	return g, nil
+}

--- a/cmd/server/analyze.go
+++ b/cmd/server/analyze.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"time"
 
@@ -13,41 +15,46 @@ import (
 	"go.uber.org/zap"
 )
 
-// AnalyzeRequest configures the analysis engine. All fields are optional;
-// sensible defaults are used.
+// defaultAnalyzeTimeLimit is the per-move budget the engine gets when the
+// caller doesn't supply one. Two seconds at Advanced is enough to flag
+// most obvious blunders without making a 50-move analysis last forever.
+const defaultAnalyzeTimeLimit = 2 * time.Second
+
+// AnalyzeRequest configures the analysis engine. All fields are optional.
 type AnalyzeRequest struct {
 	Level     string        `json:"level"`
 	Style     string        `json:"style"`
 	TimeLimit time.Duration `json:"time_limit"`
 }
 
-// PlyAnalysis is the result for a single half-turn.
-type PlyAnalysis struct {
+// MoveAnalysis is the engine's verdict on a single move (one half-turn).
+// `Played` is what the player did; `Best` is what the engine would have
+// done in the same position; `Agreed` is `Played == Best`.
+type MoveAnalysis struct {
 	Turn   int64  `json:"turn"`
 	Player int    `json:"player"`
 	Played string `json:"played"`
 	Best   string `json:"best"`
 	Agreed bool   `json:"agreed"`
-	// Error captures why the engine couldn't evaluate this ply, if any.
-	// When non-empty Best and Agreed are meaningless.
+	// Error captures why the engine couldn't evaluate this move, if any.
+	// When non-empty, Best and Agreed should be ignored.
 	Error string `json:"error,omitempty"`
 }
 
 // AnalyzeResponse is the payload returned by POST /analyze/game/{slug}.
 type AnalyzeResponse struct {
-	Slug   string        `json:"slug"`
-	Size   int64         `json:"size"`
-	Level  string        `json:"level"`
-	Plies  []PlyAnalysis `json:"plies"`
-	Played int           `json:"played"`
-	Agreed int           `json:"agreed"`
+	Slug      string         `json:"slug"`
+	Size      int64          `json:"size"`
+	Level     string         `json:"level"`
+	Moves     []MoveAnalysis `json:"moves"`
+	MoveCount int            `json:"move_count"`
+	Agreed    int            `json:"agreed"`
 }
 
 // @Summary Analyze a game move-by-move
-// @Description For each ply, asks the AI engine what it would play in that
-// @Description position and records whether the player's move matches. A
-// @Description rough "blunder detector"; intended as a starting point for
-// @Description deeper analysis features.
+// @Description Walks the game move-by-move, asking the AI engine what it
+// @Description would play at each position, and records whether the player's
+// @Description move matches. Useful as a rough "blunder detector".
 // @Tags analysis
 // @Accept json
 // @Produce json
@@ -62,11 +69,20 @@ func postAnalyzeHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	l := logging.FromContext(ctx)
 
+	req, err := decodeAnalyzeRequest(r)
+	if err != nil {
+		l.Warnw("invalid analyze request body", zap.Error(err))
+		if jerr := Renderer.JSON(w, http.StatusBadRequest, ErrorResponse{Error: "invalid request body"}); jerr != nil {
+			l.Errorw("failed to render JSON", zap.Error(jerr))
+		}
+		return
+	}
+
 	db, err := getDB()
 	if err != nil {
 		l.Errorw("could not get db", zap.Error(err))
-		if err := Renderer.JSON(w, http.StatusInternalServerError, ErrorResponse{Error: "bad connection to db"}); err != nil {
-			l.Errorw("failed to render JSON", zap.Error(err))
+		if jerr := Renderer.JSON(w, http.StatusInternalServerError, ErrorResponse{Error: "bad connection to db"}); jerr != nil {
+			l.Errorw("failed to render JSON", zap.Error(jerr))
 		}
 		return
 	}
@@ -75,34 +91,26 @@ func postAnalyzeHandler(w http.ResponseWriter, r *http.Request) {
 	game, err := getGame(db, slug)
 	if err != nil {
 		l.Errorw("could not get game", "slug", slug, zap.Error(err))
-		if err := Renderer.JSON(w, http.StatusNotFound, ErrorResponse{Error: "game not found"}); err != nil {
-			l.Errorw("failed to render JSON", zap.Error(err))
+		if jerr := Renderer.JSON(w, http.StatusNotFound, ErrorResponse{Error: "game not found"}); jerr != nil {
+			l.Errorw("failed to render JSON", zap.Error(jerr))
 		}
 		return
 	}
 
-	// Empty body is OK; defaults apply.
-	var req AnalyzeRequest
-	if r.Body != nil {
-		_ = json.NewDecoder(r.Body).Decode(&req)
-	}
-	cfg := analyzeConfigFromRequest(req)
+	cfg, levelName := analyzeConfigFromRequest(req)
+	moves := analyzeGame(ctx, &ai.TakticianEngine{}, game, cfg)
 
-	plies := analyzeGame(ctx, &ai.TakticianEngine{}, game, cfg)
 	resp := AnalyzeResponse{
-		Slug:   slug,
-		Size:   game.Board.Size,
-		Level:  string(req.Level),
-		Plies:  plies,
-		Played: len(plies),
+		Slug:      slug,
+		Size:      game.Board.Size,
+		Level:     levelName,
+		Moves:     moves,
+		MoveCount: len(moves),
 	}
-	for _, p := range plies {
-		if p.Agreed {
+	for _, m := range moves {
+		if m.Agreed {
 			resp.Agreed++
 		}
-	}
-	if resp.Level == "" {
-		resp.Level = "advanced"
 	}
 
 	if err := Renderer.JSON(w, http.StatusOK, resp); err != nil {
@@ -110,20 +118,36 @@ func postAnalyzeHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// analyzeConfigFromRequest maps the wire-level request to an ai.AIConfig,
-// applying defaults aimed at making the analysis stronger than typical
-// gameplay (we'd rather flag a real blunder than miss one).
-func analyzeConfigFromRequest(req AnalyzeRequest) ai.AIConfig {
-	level := ai.Advanced
+// decodeAnalyzeRequest reads the optional JSON body. An empty body is fine
+// and yields a zero-value AnalyzeRequest; anything else that fails to
+// decode is a 400.
+func decodeAnalyzeRequest(r *http.Request) (AnalyzeRequest, error) {
+	var req AnalyzeRequest
+	if r.Body == nil {
+		return req, nil
+	}
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return req, err
+	}
+	return req, nil
+}
+
+// analyzeConfigFromRequest maps the wire request to an ai.AIConfig.
+// Returns both the config and the canonical level name (so the response
+// can echo what was actually used rather than what the request asked
+// for, which may differ when defaults kick in).
+func analyzeConfigFromRequest(req AnalyzeRequest) (ai.AIConfig, string) {
+	level, levelName := ai.Advanced, "advanced"
 	switch req.Level {
 	case "beginner":
-		level = ai.Beginner
+		level, levelName = ai.Beginner, "beginner"
 	case "intermediate":
-		level = ai.Intermediate
-	case "advanced":
-		level = ai.Advanced
+		level, levelName = ai.Intermediate, "intermediate"
+	case "advanced", "":
+		level, levelName = ai.Advanced, "advanced"
 	case "expert":
-		level = ai.Expert
+		level, levelName = ai.Expert, "expert"
 	}
 
 	style := ai.Balanced
@@ -134,19 +158,24 @@ func analyzeConfigFromRequest(req AnalyzeRequest) ai.AIConfig {
 		style = ai.Defensive
 	}
 
-	timeLimit := 2 * time.Second
+	timeLimit := defaultAnalyzeTimeLimit
 	if req.TimeLimit > 0 {
 		timeLimit = req.TimeLimit
 	}
-	return ai.AIConfig{Level: level, Style: style, TimeLimit: timeLimit}
+	return ai.AIConfig{Level: level, Style: style, TimeLimit: timeLimit}, levelName
 }
 
-// analyzeGame walks `g` ply by ply and asks `engine` for the best move at
-// each position. The original game is not mutated.
-func analyzeGame(ctx context.Context, engine ai.Engine, g *gotak.Game, cfg ai.AIConfig) []PlyAnalysis {
-	plies := []PlyAnalysis{}
-	if g == nil || len(g.Turns) == 0 {
-		return plies
+// analyzeGame walks `g` move by move and asks `engine` for the best move at
+// each position. Returns one MoveAnalysis per recorded move (one per
+// player half-turn). The original game is not mutated.
+//
+// Honours ctx cancellation: as soon as the context is done, the remaining
+// moves are skipped with Error="canceled" so callers see the budget was
+// exhausted rather than getting a silently truncated list.
+func analyzeGame(ctx context.Context, engine ai.Engine, g *gotak.Game, cfg ai.AIConfig) []MoveAnalysis {
+	out := []MoveAnalysis{}
+	if g == nil || g.Board == nil || len(g.Turns) == 0 {
+		return out
 	}
 
 	for turnIdx, turn := range g.Turns {
@@ -154,29 +183,34 @@ func analyzeGame(ctx context.Context, engine ai.Engine, g *gotak.Game, cfg ai.AI
 			continue
 		}
 		if turn.First != nil {
-			plies = append(plies, evaluatePly(ctx, engine, g, turnIdx, false, turn.Number, gotak.PlayerWhite, turn.First.Text, cfg))
+			out = append(out, evaluateMove(ctx, engine, g, turnIdx, false, turn.Number, gotak.PlayerWhite, turn.First.Text, cfg))
 		}
 		if turn.Second != nil {
-			plies = append(plies, evaluatePly(ctx, engine, g, turnIdx, true, turn.Number, gotak.PlayerBlack, turn.Second.Text, cfg))
+			out = append(out, evaluateMove(ctx, engine, g, turnIdx, true, turn.Number, gotak.PlayerBlack, turn.Second.Text, cfg))
 		}
 	}
-	return plies
+	return out
 }
 
-func evaluatePly(
+func evaluateMove(
 	ctx context.Context,
 	engine ai.Engine,
 	orig *gotak.Game,
 	turnIdx int,
-	second bool,
+	isSecond bool,
 	turnNumber int64,
 	player int,
 	played string,
 	cfg ai.AIConfig,
-) PlyAnalysis {
-	out := PlyAnalysis{Turn: turnNumber, Player: player, Played: played}
+) MoveAnalysis {
+	out := MoveAnalysis{Turn: turnNumber, Player: player, Played: played}
 
-	pre, err := gameBeforePly(orig, turnIdx, second)
+	if err := ctx.Err(); err != nil {
+		out.Error = err.Error()
+		return out
+	}
+
+	pre, err := gameBeforeMove(orig, turnIdx, isSecond)
 	if err != nil {
 		out.Error = err.Error()
 		return out
@@ -192,21 +226,25 @@ func evaluatePly(
 	return out
 }
 
-// gameBeforePly returns a fresh *gotak.Game whose Turns slice represents
-// the state of `orig` immediately before the ply identified by
-// (turnIdx, second). If `second` is true, the first move of orig.Turns[turnIdx]
-// is included; otherwise only orig.Turns[0..turnIdx-1] are included.
+// gameBeforeMove returns a fresh *gotak.Game whose Turns slice represents
+// the state of `orig` immediately before the move identified by
+// (turnIdx, isSecond). When isSecond is true the first move of
+// orig.Turns[turnIdx] is included; otherwise only orig.Turns[0..turnIdx-1]
+// are included.
 //
 // The returned game shares move pointers with the original (the engine
-// reads moves but does not mutate them).
-func gameBeforePly(orig *gotak.Game, turnIdx int, second bool) (*gotak.Game, error) {
+// reads them but does not mutate).
+func gameBeforeMove(orig *gotak.Game, turnIdx int, isSecond bool) (*gotak.Game, error) {
+	if orig == nil || orig.Board == nil {
+		return nil, errors.New("original game has no board")
+	}
 	g, err := gotak.NewGame(orig.Board.Size, orig.ID, orig.Slug)
 	if err != nil {
 		return nil, err
 	}
 	g.Meta = orig.Meta
 
-	for i := 0; i < turnIdx; i++ {
+	for i := 0; i < turnIdx && i < len(orig.Turns); i++ {
 		t := orig.Turns[i]
 		if t == nil {
 			continue
@@ -217,7 +255,7 @@ func gameBeforePly(orig *gotak.Game, turnIdx int, second bool) (*gotak.Game, err
 			Second: t.Second,
 		})
 	}
-	if second && turnIdx < len(orig.Turns) && orig.Turns[turnIdx] != nil {
+	if isSecond && turnIdx < len(orig.Turns) && orig.Turns[turnIdx] != nil {
 		t := orig.Turns[turnIdx]
 		g.Turns = append(g.Turns, &gotak.Turn{
 			Number: t.Number,

--- a/cmd/server/analyze_test.go
+++ b/cmd/server/analyze_test.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/icco/gotak"
+	"github.com/icco/gotak/ai"
+)
+
+// stubEngine returns a hard-coded move per call, in order, so tests can
+// assert how the analyzer drives the engine.
+type stubEngine struct {
+	moves []string
+	calls int
+}
+
+func (s *stubEngine) GetMove(_ context.Context, _ *gotak.Game, _ ai.AIConfig) (string, error) {
+	if s.calls >= len(s.moves) {
+		s.calls++
+		return "", nil
+	}
+	m := s.moves[s.calls]
+	s.calls++
+	return m, nil
+}
+
+func (s *stubEngine) ExplainMove(_ context.Context, _ *gotak.Game, _ ai.AIConfig) (string, error) {
+	return "", nil
+}
+
+func mustGame(t *testing.T, size int64, moves []struct {
+	player int
+	move   string
+}) *gotak.Game {
+	t.Helper()
+	g, err := gotak.NewGame(size, 1, "t")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, m := range moves {
+		if err := g.DoSingleMove(m.move, m.player); err != nil {
+			t.Fatalf("DoSingleMove(%q, %d): %v", m.move, m.player, err)
+		}
+	}
+	return g
+}
+
+func TestGameBeforePly_prefixesTurns(t *testing.T) {
+	g := mustGame(t, 5, []struct {
+		player int
+		move   string
+	}{
+		{gotak.PlayerWhite, "a1"},
+		{gotak.PlayerBlack, "e5"},
+		{gotak.PlayerWhite, "b2"},
+		{gotak.PlayerBlack, "d4"},
+	})
+
+	// Before ply 0 (turn 1 first): no turns.
+	pre, err := gameBeforePly(g, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pre.Turns) != 0 {
+		t.Errorf("before ply 0: got %d turns, want 0", len(pre.Turns))
+	}
+
+	// Before ply 1 (turn 1 second): turn 1 with First only.
+	pre, err = gameBeforePly(g, 0, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pre.Turns) != 1 || pre.Turns[0].First == nil || pre.Turns[0].Second != nil {
+		t.Errorf("before ply 1: got turns %+v, want 1 turn with First only", pre.Turns)
+	}
+
+	// Before ply 2 (turn 2 first): turn 1 complete.
+	pre, err = gameBeforePly(g, 1, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pre.Turns) != 1 || pre.Turns[0].Second == nil {
+		t.Errorf("before ply 2: got turns %+v, want 1 complete turn", pre.Turns)
+	}
+
+	// Before ply 3 (turn 2 second): turn 1 complete + turn 2 First only.
+	pre, err = gameBeforePly(g, 1, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pre.Turns) != 2 || pre.Turns[1].Second != nil {
+		t.Errorf("before ply 3: got turns %+v, want 2 turns with second partial", pre.Turns)
+	}
+
+	// Original game unchanged.
+	if len(g.Turns) != 2 {
+		t.Errorf("original game mutated: len=%d, want 2", len(g.Turns))
+	}
+}
+
+func TestAnalyzeGame_recordsAgreement(t *testing.T) {
+	g := mustGame(t, 5, []struct {
+		player int
+		move   string
+	}{
+		{gotak.PlayerWhite, "a1"},
+		{gotak.PlayerBlack, "e5"},
+		{gotak.PlayerWhite, "b2"},
+		{gotak.PlayerBlack, "d4"},
+	})
+
+	// Engine claims b2 was best for plies 0 and 2 (so ply 2 agrees, ply 0
+	// disagrees), and matches the played move on plies 1 and 3.
+	engine := &stubEngine{moves: []string{"b2", "e5", "b2", "d4"}}
+
+	plies := analyzeGame(context.Background(), engine, g, ai.AIConfig{TimeLimit: 100 * time.Millisecond})
+
+	if len(plies) != 4 {
+		t.Fatalf("got %d plies, want 4", len(plies))
+	}
+
+	want := []struct {
+		played string
+		best   string
+		agreed bool
+		player int
+	}{
+		{"a1", "b2", false, gotak.PlayerWhite},
+		{"e5", "e5", true, gotak.PlayerBlack},
+		{"b2", "b2", true, gotak.PlayerWhite},
+		{"d4", "d4", true, gotak.PlayerBlack},
+	}
+	for i, w := range want {
+		if plies[i].Played != w.played || plies[i].Best != w.best || plies[i].Agreed != w.agreed || plies[i].Player != w.player {
+			t.Errorf("ply %d = %+v, want %+v", i, plies[i], w)
+		}
+	}
+
+	if engine.calls != 4 {
+		t.Errorf("engine called %d times, want 4", engine.calls)
+	}
+}
+
+func TestAnalyzeGame_emptyGame(t *testing.T) {
+	g, _ := gotak.NewGame(5, 1, "t")
+	engine := &stubEngine{}
+	plies := analyzeGame(context.Background(), engine, g, ai.AIConfig{})
+	if len(plies) != 0 {
+		t.Errorf("empty game produced %d plies, want 0", len(plies))
+	}
+	if engine.calls != 0 {
+		t.Errorf("engine called %d times on empty game, want 0", engine.calls)
+	}
+}
+
+func TestAnalyzeConfigFromRequest_defaults(t *testing.T) {
+	cfg := analyzeConfigFromRequest(AnalyzeRequest{})
+	if cfg.Level != ai.Advanced {
+		t.Errorf("default level = %v, want Advanced", cfg.Level)
+	}
+	if cfg.Style != ai.Balanced {
+		t.Errorf("default style = %v, want Balanced", cfg.Style)
+	}
+	if cfg.TimeLimit != 2*time.Second {
+		t.Errorf("default time limit = %v, want 2s", cfg.TimeLimit)
+	}
+}
+
+func TestAnalyzeConfigFromRequest_overrides(t *testing.T) {
+	cfg := analyzeConfigFromRequest(AnalyzeRequest{
+		Level:     "beginner",
+		Style:     "aggressive",
+		TimeLimit: 5 * time.Second,
+	})
+	if cfg.Level != ai.Beginner {
+		t.Errorf("level = %v, want Beginner", cfg.Level)
+	}
+	if cfg.Style != ai.Aggressive {
+		t.Errorf("style = %v, want Aggressive", cfg.Style)
+	}
+	if cfg.TimeLimit != 5*time.Second {
+		t.Errorf("time = %v, want 5s", cfg.TimeLimit)
+	}
+}

--- a/cmd/server/analyze_test.go
+++ b/cmd/server/analyze_test.go
@@ -9,7 +9,13 @@ import (
 	"github.com/icco/gotak/ai"
 )
 
-// stubEngine returns a hard-coded move per call, in order, so tests can
+// scriptedMove is one entry in a hand-crafted game used by tests.
+type scriptedMove struct {
+	player int
+	move   string
+}
+
+// stubEngine returns the next hard-coded move on each call, so tests can
 // assert how the analyzer drives the engine.
 type stubEngine struct {
 	moves []string
@@ -30,10 +36,7 @@ func (s *stubEngine) ExplainMove(_ context.Context, _ *gotak.Game, _ ai.AIConfig
 	return "", nil
 }
 
-func mustGame(t *testing.T, size int64, moves []struct {
-	player int
-	move   string
-}) *gotak.Game {
+func mustGame(t *testing.T, size int64, moves []scriptedMove) *gotak.Game {
 	t.Helper()
 	g, err := gotak.NewGame(size, 1, "t")
 	if err != nil {
@@ -47,51 +50,46 @@ func mustGame(t *testing.T, size int64, moves []struct {
 	return g
 }
 
-func TestGameBeforePly_prefixesTurns(t *testing.T) {
-	g := mustGame(t, 5, []struct {
-		player int
-		move   string
-	}{
+func TestGameBeforeMove_prefixesTurns(t *testing.T) {
+	g := mustGame(t, 5, []scriptedMove{
 		{gotak.PlayerWhite, "a1"},
 		{gotak.PlayerBlack, "e5"},
 		{gotak.PlayerWhite, "b2"},
 		{gotak.PlayerBlack, "d4"},
 	})
 
-	// Before ply 0 (turn 1 first): no turns.
-	pre, err := gameBeforePly(g, 0, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(pre.Turns) != 0 {
-		t.Errorf("before ply 0: got %d turns, want 0", len(pre.Turns))
-	}
-
-	// Before ply 1 (turn 1 second): turn 1 with First only.
-	pre, err = gameBeforePly(g, 0, true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(pre.Turns) != 1 || pre.Turns[0].First == nil || pre.Turns[0].Second != nil {
-		t.Errorf("before ply 1: got turns %+v, want 1 turn with First only", pre.Turns)
+	cases := []struct {
+		name           string
+		turnIdx        int
+		isSecond       bool
+		wantTurns      int
+		wantSecondNil  bool // wantSecondNil applies to the last turn in the prefix
+	}{
+		{"before turn-1 first move", 0, false, 0, false},
+		{"before turn-1 second move", 0, true, 1, true},
+		{"before turn-2 first move", 1, false, 1, false},
+		{"before turn-2 second move", 1, true, 2, true},
 	}
 
-	// Before ply 2 (turn 2 first): turn 1 complete.
-	pre, err = gameBeforePly(g, 1, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(pre.Turns) != 1 || pre.Turns[0].Second == nil {
-		t.Errorf("before ply 2: got turns %+v, want 1 complete turn", pre.Turns)
-	}
-
-	// Before ply 3 (turn 2 second): turn 1 complete + turn 2 First only.
-	pre, err = gameBeforePly(g, 1, true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(pre.Turns) != 2 || pre.Turns[1].Second != nil {
-		t.Errorf("before ply 3: got turns %+v, want 2 turns with second partial", pre.Turns)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pre, err := gameBeforeMove(g, tc.turnIdx, tc.isSecond)
+			if err != nil {
+				t.Fatalf("gameBeforeMove: %v", err)
+			}
+			if len(pre.Turns) != tc.wantTurns {
+				t.Fatalf("got %d turns, want %d (%+v)", len(pre.Turns), tc.wantTurns, pre.Turns)
+			}
+			if tc.wantTurns > 0 {
+				last := pre.Turns[tc.wantTurns-1]
+				if tc.wantSecondNil && last.Second != nil {
+					t.Errorf("last turn should have Second=nil, got %+v", last)
+				}
+				if !tc.wantSecondNil && last.Second == nil {
+					t.Errorf("last turn should have Second set, got %+v", last)
+				}
+			}
+		})
 	}
 
 	// Original game unchanged.
@@ -100,25 +98,28 @@ func TestGameBeforePly_prefixesTurns(t *testing.T) {
 	}
 }
 
+func TestGameBeforeMove_nilGame(t *testing.T) {
+	if _, err := gameBeforeMove(nil, 0, false); err == nil {
+		t.Errorf("nil game should return error")
+	}
+}
+
 func TestAnalyzeGame_recordsAgreement(t *testing.T) {
-	g := mustGame(t, 5, []struct {
-		player int
-		move   string
-	}{
+	g := mustGame(t, 5, []scriptedMove{
 		{gotak.PlayerWhite, "a1"},
 		{gotak.PlayerBlack, "e5"},
 		{gotak.PlayerWhite, "b2"},
 		{gotak.PlayerBlack, "d4"},
 	})
 
-	// Engine claims b2 was best for plies 0 and 2 (so ply 2 agrees, ply 0
-	// disagrees), and matches the played move on plies 1 and 3.
+	// Engine claims b2 for move 0 (disagrees with a1) and matches the
+	// player on the other three.
 	engine := &stubEngine{moves: []string{"b2", "e5", "b2", "d4"}}
 
-	plies := analyzeGame(context.Background(), engine, g, ai.AIConfig{TimeLimit: 100 * time.Millisecond})
+	moves := analyzeGame(context.Background(), engine, g, ai.AIConfig{TimeLimit: 100 * time.Millisecond})
 
-	if len(plies) != 4 {
-		t.Fatalf("got %d plies, want 4", len(plies))
+	if len(moves) != 4 {
+		t.Fatalf("got %d moves, want 4", len(moves))
 	}
 
 	want := []struct {
@@ -133,8 +134,9 @@ func TestAnalyzeGame_recordsAgreement(t *testing.T) {
 		{"d4", "d4", true, gotak.PlayerBlack},
 	}
 	for i, w := range want {
-		if plies[i].Played != w.played || plies[i].Best != w.best || plies[i].Agreed != w.agreed || plies[i].Player != w.player {
-			t.Errorf("ply %d = %+v, want %+v", i, plies[i], w)
+		got := moves[i]
+		if got.Played != w.played || got.Best != w.best || got.Agreed != w.agreed || got.Player != w.player {
+			t.Errorf("move %d = %+v, want %+v", i, got, w)
 		}
 	}
 
@@ -146,30 +148,54 @@ func TestAnalyzeGame_recordsAgreement(t *testing.T) {
 func TestAnalyzeGame_emptyGame(t *testing.T) {
 	g, _ := gotak.NewGame(5, 1, "t")
 	engine := &stubEngine{}
-	plies := analyzeGame(context.Background(), engine, g, ai.AIConfig{})
-	if len(plies) != 0 {
-		t.Errorf("empty game produced %d plies, want 0", len(plies))
+	moves := analyzeGame(context.Background(), engine, g, ai.AIConfig{})
+	if len(moves) != 0 {
+		t.Errorf("empty game produced %d moves, want 0", len(moves))
 	}
 	if engine.calls != 0 {
 		t.Errorf("engine called %d times on empty game, want 0", engine.calls)
 	}
 }
 
+func TestAnalyzeGame_canceledContext(t *testing.T) {
+	g := mustGame(t, 5, []scriptedMove{
+		{gotak.PlayerWhite, "a1"},
+		{gotak.PlayerBlack, "e5"},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already canceled before first call
+
+	engine := &stubEngine{moves: []string{"a1", "e5"}}
+	moves := analyzeGame(ctx, engine, g, ai.AIConfig{})
+
+	if len(moves) != 2 {
+		t.Fatalf("want 2 entries (one per move), got %d", len(moves))
+	}
+	for i, m := range moves {
+		if m.Error == "" {
+			t.Errorf("move %d should have Error set when context is canceled, got %+v", i, m)
+		}
+	}
+}
+
 func TestAnalyzeConfigFromRequest_defaults(t *testing.T) {
-	cfg := analyzeConfigFromRequest(AnalyzeRequest{})
+	cfg, name := analyzeConfigFromRequest(AnalyzeRequest{})
 	if cfg.Level != ai.Advanced {
 		t.Errorf("default level = %v, want Advanced", cfg.Level)
+	}
+	if name != "advanced" {
+		t.Errorf("default level name = %q, want advanced", name)
 	}
 	if cfg.Style != ai.Balanced {
 		t.Errorf("default style = %v, want Balanced", cfg.Style)
 	}
-	if cfg.TimeLimit != 2*time.Second {
-		t.Errorf("default time limit = %v, want 2s", cfg.TimeLimit)
+	if cfg.TimeLimit != defaultAnalyzeTimeLimit {
+		t.Errorf("default time limit = %v, want %v", cfg.TimeLimit, defaultAnalyzeTimeLimit)
 	}
 }
 
 func TestAnalyzeConfigFromRequest_overrides(t *testing.T) {
-	cfg := analyzeConfigFromRequest(AnalyzeRequest{
+	cfg, name := analyzeConfigFromRequest(AnalyzeRequest{
 		Level:     "beginner",
 		Style:     "aggressive",
 		TimeLimit: 5 * time.Second,
@@ -177,10 +203,20 @@ func TestAnalyzeConfigFromRequest_overrides(t *testing.T) {
 	if cfg.Level != ai.Beginner {
 		t.Errorf("level = %v, want Beginner", cfg.Level)
 	}
+	if name != "beginner" {
+		t.Errorf("level name = %q, want beginner", name)
+	}
 	if cfg.Style != ai.Aggressive {
 		t.Errorf("style = %v, want Aggressive", cfg.Style)
 	}
 	if cfg.TimeLimit != 5*time.Second {
 		t.Errorf("time = %v, want 5s", cfg.TimeLimit)
+	}
+}
+
+func TestAnalyzeConfigFromRequest_unknownLevelDefaults(t *testing.T) {
+	cfg, name := analyzeConfigFromRequest(AnalyzeRequest{Level: "godlike"})
+	if cfg.Level != ai.Advanced || name != "advanced" {
+		t.Errorf("unknown level should fall back to advanced, got %v/%q", cfg.Level, name)
 	}
 }

--- a/cmd/server/analyze_test.go
+++ b/cmd/server/analyze_test.go
@@ -9,11 +9,8 @@ import (
 	"github.com/icco/gotak/ai"
 )
 
-// scriptedMove is one entry in a hand-crafted game used by tests.
-type scriptedMove struct {
-	player int
-	move   string
-}
+// scriptedMove and the playGame helper live in replay_test.go and are
+// shared across the cmd/server test binary.
 
 // stubEngine returns the next hard-coded move on each call, so tests can
 // assert how the analyzer drives the engine.
@@ -36,22 +33,8 @@ func (s *stubEngine) ExplainMove(_ context.Context, _ *gotak.Game, _ ai.AIConfig
 	return "", nil
 }
 
-func mustGame(t *testing.T, size int64, moves []scriptedMove) *gotak.Game {
-	t.Helper()
-	g, err := gotak.NewGame(size, 1, "t")
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, m := range moves {
-		if err := g.DoSingleMove(m.move, m.player); err != nil {
-			t.Fatalf("DoSingleMove(%q, %d): %v", m.move, m.player, err)
-		}
-	}
-	return g
-}
-
 func TestGameBeforeMove_prefixesTurns(t *testing.T) {
-	g := mustGame(t, 5, []scriptedMove{
+	g := playGame(t, 5, []scriptedMove{
 		{gotak.PlayerWhite, "a1"},
 		{gotak.PlayerBlack, "e5"},
 		{gotak.PlayerWhite, "b2"},
@@ -105,7 +88,7 @@ func TestGameBeforeMove_nilGame(t *testing.T) {
 }
 
 func TestAnalyzeGame_recordsAgreement(t *testing.T) {
-	g := mustGame(t, 5, []scriptedMove{
+	g := playGame(t, 5, []scriptedMove{
 		{gotak.PlayerWhite, "a1"},
 		{gotak.PlayerBlack, "e5"},
 		{gotak.PlayerWhite, "b2"},
@@ -158,7 +141,7 @@ func TestAnalyzeGame_emptyGame(t *testing.T) {
 }
 
 func TestAnalyzeGame_canceledContext(t *testing.T) {
-	g := mustGame(t, 5, []scriptedMove{
+	g := playGame(t, 5, []scriptedMove{
 		{gotak.PlayerWhite, "a1"},
 		{gotak.PlayerBlack, "e5"},
 	})

--- a/cmd/server/docs/docs.go
+++ b/cmd/server/docs/docs.go
@@ -47,7 +47,7 @@ const docTemplate = `{
         },
         "/analyze/game/{slug}": {
             "post": {
-                "description": "For each ply, asks the AI engine what it would play in that\nposition and records whether the player's move matches. A\nrough \"blunder detector\"; intended as a starting point for\ndeeper analysis features.",
+                "description": "Walks the game move-by-move, asking the AI engine what it\nwould play at each position, and records whether the player's\nmove matches. Useful as a rough \"blunder detector\".",
                 "consumes": [
                     "application/json"
                 ],
@@ -856,13 +856,13 @@ const docTemplate = `{
                 "level": {
                     "type": "string"
                 },
-                "played": {
+                "move_count": {
                     "type": "integer"
                 },
-                "plies": {
+                "moves": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/main.PlyAnalysis"
+                        "$ref": "#/definitions/main.MoveAnalysis"
                     }
                 },
                 "size": {
@@ -958,6 +958,30 @@ const docTemplate = `{
                 }
             }
         },
+        "main.MoveAnalysis": {
+            "type": "object",
+            "properties": {
+                "agreed": {
+                    "type": "boolean"
+                },
+                "best": {
+                    "type": "string"
+                },
+                "error": {
+                    "description": "Error captures why the engine couldn't evaluate this move, if any.\nWhen non-empty, Best and Agreed should be ignored.",
+                    "type": "string"
+                },
+                "played": {
+                    "type": "string"
+                },
+                "player": {
+                    "type": "integer"
+                },
+                "turn": {
+                    "type": "integer"
+                }
+            }
+        },
         "main.MoveRequest": {
             "type": "object",
             "properties": {
@@ -972,30 +996,6 @@ const docTemplate = `{
                 "turn": {
                     "type": "integer",
                     "example": 1
-                }
-            }
-        },
-        "main.PlyAnalysis": {
-            "type": "object",
-            "properties": {
-                "agreed": {
-                    "type": "boolean"
-                },
-                "best": {
-                    "type": "string"
-                },
-                "error": {
-                    "description": "Error captures why the engine couldn't evaluate this ply, if any.\nWhen non-empty Best and Agreed are meaningless.",
-                    "type": "string"
-                },
-                "played": {
-                    "type": "string"
-                },
-                "player": {
-                    "type": "integer"
-                },
-                "turn": {
-                    "type": "integer"
                 }
             }
         },

--- a/cmd/server/docs/docs.go
+++ b/cmd/server/docs/docs.go
@@ -45,6 +45,64 @@ const docTemplate = `{
                 }
             }
         },
+        "/analyze/game/{slug}": {
+            "post": {
+                "description": "For each ply, asks the AI engine what it would play in that\nposition and records whether the player's move matches. A\nrough \"blunder detector\"; intended as a starting point for\ndeeper analysis features.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "analysis"
+                ],
+                "summary": "Analyze a game move-by-move",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Game slug identifier",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Engine config (optional)",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/main.AnalyzeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/main.AnalyzeResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/confirm-reset": {
             "post": {
                 "description": "Reset password with token",
@@ -786,6 +844,35 @@ const docTemplate = `{
                 }
             }
         },
+        "main.AnalyzeRequest": {
+            "type": "object"
+        },
+        "main.AnalyzeResponse": {
+            "type": "object",
+            "properties": {
+                "agreed": {
+                    "type": "integer"
+                },
+                "level": {
+                    "type": "string"
+                },
+                "played": {
+                    "type": "integer"
+                },
+                "plies": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/main.PlyAnalysis"
+                    }
+                },
+                "size": {
+                    "type": "integer"
+                },
+                "slug": {
+                    "type": "string"
+                }
+            }
+        },
         "main.AuthResponse": {
             "type": "object",
             "properties": {
@@ -885,6 +972,30 @@ const docTemplate = `{
                 "turn": {
                     "type": "integer",
                     "example": 1
+                }
+            }
+        },
+        "main.PlyAnalysis": {
+            "type": "object",
+            "properties": {
+                "agreed": {
+                    "type": "boolean"
+                },
+                "best": {
+                    "type": "string"
+                },
+                "error": {
+                    "description": "Error captures why the engine couldn't evaluate this ply, if any.\nWhen non-empty Best and Agreed are meaningless.",
+                    "type": "string"
+                },
+                "played": {
+                    "type": "string"
+                },
+                "player": {
+                    "type": "integer"
+                },
+                "turn": {
+                    "type": "integer"
                 }
             }
         },

--- a/cmd/server/docs/swagger.json
+++ b/cmd/server/docs/swagger.json
@@ -41,7 +41,7 @@
         },
         "/analyze/game/{slug}": {
             "post": {
-                "description": "For each ply, asks the AI engine what it would play in that\nposition and records whether the player's move matches. A\nrough \"blunder detector\"; intended as a starting point for\ndeeper analysis features.",
+                "description": "Walks the game move-by-move, asking the AI engine what it\nwould play at each position, and records whether the player's\nmove matches. Useful as a rough \"blunder detector\".",
                 "consumes": [
                     "application/json"
                 ],
@@ -850,13 +850,13 @@
                 "level": {
                     "type": "string"
                 },
-                "played": {
+                "move_count": {
                     "type": "integer"
                 },
-                "plies": {
+                "moves": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/main.PlyAnalysis"
+                        "$ref": "#/definitions/main.MoveAnalysis"
                     }
                 },
                 "size": {
@@ -952,6 +952,30 @@
                 }
             }
         },
+        "main.MoveAnalysis": {
+            "type": "object",
+            "properties": {
+                "agreed": {
+                    "type": "boolean"
+                },
+                "best": {
+                    "type": "string"
+                },
+                "error": {
+                    "description": "Error captures why the engine couldn't evaluate this move, if any.\nWhen non-empty, Best and Agreed should be ignored.",
+                    "type": "string"
+                },
+                "played": {
+                    "type": "string"
+                },
+                "player": {
+                    "type": "integer"
+                },
+                "turn": {
+                    "type": "integer"
+                }
+            }
+        },
         "main.MoveRequest": {
             "type": "object",
             "properties": {
@@ -966,30 +990,6 @@
                 "turn": {
                     "type": "integer",
                     "example": 1
-                }
-            }
-        },
-        "main.PlyAnalysis": {
-            "type": "object",
-            "properties": {
-                "agreed": {
-                    "type": "boolean"
-                },
-                "best": {
-                    "type": "string"
-                },
-                "error": {
-                    "description": "Error captures why the engine couldn't evaluate this ply, if any.\nWhen non-empty Best and Agreed are meaningless.",
-                    "type": "string"
-                },
-                "played": {
-                    "type": "string"
-                },
-                "player": {
-                    "type": "integer"
-                },
-                "turn": {
-                    "type": "integer"
                 }
             }
         },

--- a/cmd/server/docs/swagger.json
+++ b/cmd/server/docs/swagger.json
@@ -39,6 +39,64 @@
                 }
             }
         },
+        "/analyze/game/{slug}": {
+            "post": {
+                "description": "For each ply, asks the AI engine what it would play in that\nposition and records whether the player's move matches. A\nrough \"blunder detector\"; intended as a starting point for\ndeeper analysis features.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "analysis"
+                ],
+                "summary": "Analyze a game move-by-move",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Game slug identifier",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Engine config (optional)",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/main.AnalyzeRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/main.AnalyzeResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/confirm-reset": {
             "post": {
                 "description": "Reset password with token",
@@ -780,6 +838,35 @@
                 }
             }
         },
+        "main.AnalyzeRequest": {
+            "type": "object"
+        },
+        "main.AnalyzeResponse": {
+            "type": "object",
+            "properties": {
+                "agreed": {
+                    "type": "integer"
+                },
+                "level": {
+                    "type": "string"
+                },
+                "played": {
+                    "type": "integer"
+                },
+                "plies": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/main.PlyAnalysis"
+                    }
+                },
+                "size": {
+                    "type": "integer"
+                },
+                "slug": {
+                    "type": "string"
+                }
+            }
+        },
         "main.AuthResponse": {
             "type": "object",
             "properties": {
@@ -879,6 +966,30 @@
                 "turn": {
                     "type": "integer",
                     "example": 1
+                }
+            }
+        },
+        "main.PlyAnalysis": {
+            "type": "object",
+            "properties": {
+                "agreed": {
+                    "type": "boolean"
+                },
+                "best": {
+                    "type": "string"
+                },
+                "error": {
+                    "description": "Error captures why the engine couldn't evaluate this ply, if any.\nWhen non-empty Best and Agreed are meaningless.",
+                    "type": "string"
+                },
+                "played": {
+                    "type": "string"
+                },
+                "player": {
+                    "type": "integer"
+                },
+                "turn": {
+                    "type": "integer"
                 }
             }
         },

--- a/cmd/server/docs/swagger.yaml
+++ b/cmd/server/docs/swagger.yaml
@@ -92,11 +92,11 @@ definitions:
         type: integer
       level:
         type: string
-      played:
+      move_count:
         type: integer
-      plies:
+      moves:
         items:
-          $ref: '#/definitions/main.PlyAnalysis'
+          $ref: '#/definitions/main.MoveAnalysis'
         type: array
       size:
         type: integer
@@ -161,6 +161,24 @@ definitions:
         example: Operation successful
         type: string
     type: object
+  main.MoveAnalysis:
+    properties:
+      agreed:
+        type: boolean
+      best:
+        type: string
+      error:
+        description: |-
+          Error captures why the engine couldn't evaluate this move, if any.
+          When non-empty, Best and Agreed should be ignored.
+        type: string
+      played:
+        type: string
+      player:
+        type: integer
+      turn:
+        type: integer
+    type: object
   main.MoveRequest:
     properties:
       move:
@@ -171,24 +189,6 @@ definitions:
         type: integer
       turn:
         example: 1
-        type: integer
-    type: object
-  main.PlyAnalysis:
-    properties:
-      agreed:
-        type: boolean
-      best:
-        type: string
-      error:
-        description: |-
-          Error captures why the engine couldn't evaluate this ply, if any.
-          When non-empty Best and Agreed are meaningless.
-        type: string
-      played:
-        type: string
-      player:
-        type: integer
-      turn:
         type: integer
     type: object
   main.RegisterRequest:
@@ -269,10 +269,9 @@ paths:
       consumes:
       - application/json
       description: |-
-        For each ply, asks the AI engine what it would play in that
-        position and records whether the player's move matches. A
-        rough "blunder detector"; intended as a starting point for
-        deeper analysis features.
+        Walks the game move-by-move, asking the AI engine what it
+        would play at each position, and records whether the player's
+        move matches. Useful as a rough "blunder detector".
       parameters:
       - description: Game slug identifier
         in: path

--- a/cmd/server/docs/swagger.yaml
+++ b/cmd/server/docs/swagger.yaml
@@ -84,6 +84,25 @@ definitions:
       second:
         $ref: '#/definitions/gotak.Move'
     type: object
+  main.AnalyzeRequest:
+    type: object
+  main.AnalyzeResponse:
+    properties:
+      agreed:
+        type: integer
+      level:
+        type: string
+      played:
+        type: integer
+      plies:
+        items:
+          $ref: '#/definitions/main.PlyAnalysis'
+        type: array
+      size:
+        type: integer
+      slug:
+        type: string
+    type: object
   main.AuthResponse:
     properties:
       token:
@@ -152,6 +171,24 @@ definitions:
         type: integer
       turn:
         example: 1
+        type: integer
+    type: object
+  main.PlyAnalysis:
+    properties:
+      agreed:
+        type: boolean
+      best:
+        type: string
+      error:
+        description: |-
+          Error captures why the engine couldn't evaluate this ply, if any.
+          When non-empty Best and Agreed are meaningless.
+        type: string
+      played:
+        type: string
+      player:
+        type: integer
+      turn:
         type: integer
     type: object
   main.RegisterRequest:
@@ -227,6 +264,48 @@ paths:
       summary: Get API information
       tags:
       - info
+  /analyze/game/{slug}:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        For each ply, asks the AI engine what it would play in that
+        position and records whether the player's move matches. A
+        rough "blunder detector"; intended as a starting point for
+        deeper analysis features.
+      parameters:
+      - description: Game slug identifier
+        in: path
+        name: slug
+        required: true
+        type: string
+      - description: Engine config (optional)
+        in: body
+        name: request
+        schema:
+          $ref: '#/definitions/main.AnalyzeRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/main.AnalyzeResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+      summary: Analyze a game move-by-move
+      tags:
+      - analysis
   /auth/confirm-reset:
     post:
       consumes:

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -191,6 +191,7 @@ func buildRouter(opts routerOptions) http.Handler {
 
 		r.Get("/game/{slug}", getGameHandler)
 		r.Get("/game/{slug}/{turn}", getTurnHandler)
+		r.Post("/analyze/game/{slug}", postAnalyzeHandler)
 
 		r.Group(func(r chi.Router) {
 			r.Use(authMiddleware)


### PR DESCRIPTION
Refs #51. `POST /analyze/game/{slug}` walks the game move-by-move, asks the AI engine what it would play at each position, and returns `{turn, player, played, best, agreed}` per move plus an aggregate `agreed` count. Defaults to Advanced/2s; request body can override.

Caching, DB schema, heat maps, puzzles, and the other items in #51 stay out of scope.