### PR TITLE
feat: ptn export endpoint

### DIFF
--- a/cmd/server/docs/docs.go
+++ b/cmd/server/docs/docs.go
@@ -709,6 +709,47 @@ const docTemplate = `{
                 }
             }
         },
+        "/game/{slug}/ptn": {
+            "get": {
+                "description": "Serialises the game as Portable Tak Notation text.",
+                "produces": [
+                    "text/plain"
+                ],
+                "tags": [
+                    "game"
+                ],
+                "summary": "Download game as PTN",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Game slug identifier",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "PTN text",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/game/{slug}/replay": {
             "get": {
                 "description": "Returns an ordered list of every half-turn played in the\ngame, along with the board state after each one, so a\nclient can step through without making per-turn requests.",

--- a/cmd/server/docs/swagger.json
+++ b/cmd/server/docs/swagger.json
@@ -703,6 +703,47 @@
                 }
             }
         },
+        "/game/{slug}/ptn": {
+            "get": {
+                "description": "Serialises the game as Portable Tak Notation text.",
+                "produces": [
+                    "text/plain"
+                ],
+                "tags": [
+                    "game"
+                ],
+                "summary": "Download game as PTN",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Game slug identifier",
+                        "name": "slug",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "PTN text",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/game/{slug}/replay": {
             "get": {
                 "description": "Returns an ordered list of every half-turn played in the\ngame, along with the board state after each one, so a\nclient can step through without making per-turn requests.",

--- a/cmd/server/docs/swagger.yaml
+++ b/cmd/server/docs/swagger.yaml
@@ -719,6 +719,33 @@ paths:
       summary: Get board state after N complete turns
       tags:
       - game
+  /game/{slug}/ptn:
+    get:
+      description: Serialises the game as Portable Tak Notation text.
+      parameters:
+      - description: Game slug identifier
+        in: path
+        name: slug
+        required: true
+        type: string
+      produces:
+      - text/plain
+      responses:
+        "200":
+          description: PTN text
+          schema:
+            type: string
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+      summary: Download game as PTN
+      tags:
+      - game
   /game/{slug}/replay:
     get:
       consumes:

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -191,6 +191,7 @@ func buildRouter(opts routerOptions) http.Handler {
 
 		r.Get("/game/{slug}", getGameHandler)
 		r.Get("/game/{slug}/replay", getReplayHandler)
+		r.Get("/game/{slug}/ptn", getPTNHandler)
 		r.Get("/game/{slug}/position/{turn}", getPositionHandler)
 		r.Get("/game/{slug}/{turn}", getTurnHandler)
 		r.Post("/analyze/game/{slug}", postAnalyzeHandler)

--- a/cmd/server/ptn.go
+++ b/cmd/server/ptn.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/icco/gutil/logging"
+	"go.uber.org/zap"
+)
+
+// @Summary Download game as PTN
+// @Description Serialises the game as Portable Tak Notation text.
+// @Tags game
+// @Produce plain
+// @Param slug path string true "Game slug identifier"
+// @Success 200 {string} string "PTN text"
+// @Failure 404 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /game/{slug}/ptn [get]
+func getPTNHandler(w http.ResponseWriter, r *http.Request) {
+	l := logging.FromContext(r.Context())
+
+	game, ok := loadGameForRead(w, r, l)
+	if !ok {
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("Content-Disposition", `attachment; filename="`+game.Slug+`.ptn"`)
+	// #nosec G705 -- response is served as text/plain with global X-Content-Type-Options: nosniff.
+	if _, err := w.Write([]byte(game.PTN())); err != nil {
+		l.Errorw("failed to write ptn", "slug", game.Slug, zap.Error(err))
+	}
+}

--- a/game.go
+++ b/game.go
@@ -89,6 +89,46 @@ func (g *Game) PrintCurrentState() {
 	})
 }
 
+// PTN serialises the game in Portable Tak Notation. Meta tags first
+// (one per line), then a blank line, then one line per Turn. The output
+// round-trips through ParsePTN for typical games — tag values containing
+// `"` are coerced to `'` because PTN has no defined escape sequence.
+func (g *Game) PTN() string {
+	if g == nil {
+		return ""
+	}
+
+	var b strings.Builder
+	for _, tag := range g.Meta {
+		if tag == nil {
+			continue
+		}
+		// ParsePTN matches values with regex `"(.*)"` so any " in the
+		// value would either be eaten by the greedy match or break the
+		// regex. Substitute it.
+		safe := strings.ReplaceAll(tag.Value, `"`, "'")
+		fmt.Fprintf(&b, "[%s \"%s\"]\n", tag.Key, safe)
+	}
+	if len(g.Meta) > 0 && len(g.Turns) > 0 {
+		b.WriteString("\n")
+	}
+	for _, t := range g.Turns {
+		if t == nil {
+			continue
+		}
+		line := t.Text()
+		if line == "" {
+			continue
+		}
+		if t.Result != "" {
+			line = fmt.Sprintf("%s %s", line, t.Result)
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
 // GameOver determines if a game is over and who won. A game is over if a
 // player has a continuous path from one side of the board to the other.
 //

--- a/ptn_test.go
+++ b/ptn_test.go
@@ -1,0 +1,137 @@
+package gotak
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGamePTN_emptyGame(t *testing.T) {
+	g, err := NewGame(5, 1, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := g.PTN()
+	// The Size meta tag is set by NewGame, so we expect that line at least.
+	if !strings.Contains(got, `[Size "5"]`) {
+		t.Errorf("PTN missing Size tag: %q", got)
+	}
+}
+
+func TestGamePTN_completedTurns(t *testing.T) {
+	g, err := NewGame(5, 1, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := g.DoSingleMove("a1", PlayerWhite); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.DoSingleMove("e5", PlayerBlack); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.DoSingleMove("b2", PlayerWhite); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.DoSingleMove("d4", PlayerBlack); err != nil {
+		t.Fatal(err)
+	}
+
+	got := g.PTN()
+	for _, want := range []string{
+		`[Size "5"]`,
+		"1. a1 e5",
+		"2. b2 d4",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("PTN missing %q: %q", want, got)
+		}
+	}
+}
+
+func TestGamePTN_incompleteFinalTurn(t *testing.T) {
+	g, err := NewGame(5, 1, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := g.DoSingleMove("a1", PlayerWhite); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.DoSingleMove("e5", PlayerBlack); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.DoSingleMove("b2", PlayerWhite); err != nil {
+		t.Fatal(err)
+	}
+
+	got := g.PTN()
+	// Incomplete final turn must render as exactly "2. b2\n", not
+	// "2. b2 \n" with a dangling space and not "2. b2 --\n".
+	if !strings.Contains(got, "\n2. b2\n") {
+		t.Errorf("incomplete turn 2 should render as `2. b2`, got:\n%s", got)
+	}
+}
+
+func TestGamePTN_tagWithQuoteRoundtrips(t *testing.T) {
+	g, err := NewGame(5, 1, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := g.UpdateMeta("Player1", `"Alice"`); err != nil {
+		t.Fatal(err)
+	}
+	out := g.PTN()
+	if strings.Contains(out, `"Alice"`) {
+		t.Errorf("PTN should coerce embedded quotes; got %q", out)
+	}
+	round, err := ParsePTN([]byte(out))
+	if err != nil {
+		t.Fatalf("ParsePTN failed on tag with quote: %v\n%s", err, out)
+	}
+	v, err := round.GetMeta("Player1")
+	if err != nil {
+		t.Fatalf("GetMeta: %v", err)
+	}
+	if !strings.Contains(v, "Alice") {
+		t.Errorf("Player1 = %q, want it to still contain Alice", v)
+	}
+}
+
+func TestGamePTN_roundTrip(t *testing.T) {
+	src := []byte(`[Size "5"]
+[Player1 "alice"]
+[Player2 "bob"]
+
+1. a1 e5
+2. b2 d4
+3. c3 c4
+`)
+
+	g, err := ParsePTN(src)
+	if err != nil {
+		t.Fatalf("ParsePTN: %v", err)
+	}
+
+	out := g.PTN()
+	round, err := ParsePTN([]byte(out))
+	if err != nil {
+		t.Fatalf("ParsePTN(PTN(ParsePTN(src))) failed: %v\noutput was:\n%s", err, out)
+	}
+
+	if len(round.Turns) != len(g.Turns) {
+		t.Errorf("turn count drifted: original=%d, round-tripped=%d", len(g.Turns), len(round.Turns))
+	}
+	for i := range g.Turns {
+		if g.Turns[i].First.Text != round.Turns[i].First.Text {
+			t.Errorf("turn %d first move drift: %q vs %q", i, g.Turns[i].First.Text, round.Turns[i].First.Text)
+		}
+		if (g.Turns[i].Second == nil) != (round.Turns[i].Second == nil) {
+			t.Errorf("turn %d second move nil-ness drift", i)
+		}
+	}
+}
+
+func TestGamePTN_nilGame(t *testing.T) {
+	var g *Game
+	if got := g.PTN(); got != "" {
+		t.Errorf("nil game should return empty string, got %q", got)
+	}
+}

--- a/turn.go
+++ b/turn.go
@@ -14,22 +14,31 @@ type Turn struct {
 	Branch string
 }
 
-// Text returns a PTN formated string of the turn.
+// Text returns a PTN-formatted string of the turn. An incomplete final
+// turn (no Second move yet) renders without the second field, which the
+// PTN parser accepts.
+//
+// A Second-only turn cannot be rendered because the parser has no
+// placeholder syntax for a missing First move; such a turn would silently
+// disappear from round-tripped output.
 func (t *Turn) Text() string {
-	var move string
-	if t.First != nil && t.Second != nil {
-		move = fmt.Sprintf("%d%s. %s %s", t.Number, t.Branch, t.First.Text, t.Second.Text)
+	var line string
+	switch {
+	case t.First != nil && t.Second != nil:
+		line = fmt.Sprintf("%d%s. %s %s", t.Number, t.Branch, t.First.Text, t.Second.Text)
+	case t.First != nil:
+		line = fmt.Sprintf("%d%s. %s", t.Number, t.Branch, t.First.Text)
 	}
 
 	if t.Comment != "" {
-		if move != "" {
-			move = fmt.Sprintf("%s { %s }", move, t.Comment)
+		if line != "" {
+			line = fmt.Sprintf("%s { %s }", line, t.Comment)
 		} else {
-			move = fmt.Sprintf("{ %s }", t.Comment)
+			line = fmt.Sprintf("{ %s }", t.Comment)
 		}
 	}
 
-	return move
+	return line
 }
 
 // Debug is a verbose dumping of the object and its sub objects.


### PR DESCRIPTION
Refs #45. Adds `GET /game/{slug}/ptn` that streams the game back as Portable Tak Notation, plus a `Game.PTN()` serialiser that round-trips through `ParsePTN`.