### PR TITLE
feat: cache analyze results

### DIFF
--- a/cmd/server/analyze.go
+++ b/cmd/server/analyze.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"time"
-	"fmt"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/icco/gotak"

--- a/cmd/server/analyze.go
+++ b/cmd/server/analyze.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"time"
-
 	"fmt"
 
 	"github.com/go-chi/chi/v5"

--- a/cmd/server/analyze.go
+++ b/cmd/server/analyze.go
@@ -131,7 +131,6 @@ func postAnalyzeHandler(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// writeAnalyzeResponse fills the shared envelope fields and renders.
 func writeAnalyzeResponse(w http.ResponseWriter, l *zap.SugaredLogger, slug string, size int64, level string, resp AnalyzeResponse) {
 	resp.Slug = slug
 	resp.Size = size
@@ -141,11 +140,8 @@ func writeAnalyzeResponse(w http.ResponseWriter, l *zap.SugaredLogger, slug stri
 	}
 }
 
-// gameCacheVersion is a fingerprint of the game state used as part of
-// the analysis cache key. Today it's just the half-turn count, which
-// invalidates the cache when a game grows. The string layout leaves
-// room to mix in g.UpdatedAt or a content hash later if edit-in-place
-// becomes possible.
+// gameCacheVersion is the cache-invalidation fingerprint. The "v1:" prefix
+// reserves room to add more inputs (UpdatedAt, content hash) later.
 func gameCacheVersion(g *gotak.Game) string {
 	count := 0
 	for _, t := range g.Turns {
@@ -162,7 +158,6 @@ func gameCacheVersion(g *gotak.Game) string {
 	return fmt.Sprintf("v1:moves=%d", count)
 }
 
-// analysisCacheKey is the composite key used to look up a stored result.
 type analysisCacheKey struct {
 	gameID      int64
 	level       string
@@ -171,9 +166,8 @@ type analysisCacheKey struct {
 	gameVersion string
 }
 
-// loadAnalysisCache returns a cached analysis result for the given key.
-// ok=false means cache miss. Real DB errors (other than "not found") are
-// logged so a flaky cache is at least observable.
+// loadAnalysisCache logs non-NotFound errors so a flaky cache is observable,
+// but always degrades to a miss so caching never blocks analysis.
 func loadAnalysisCache(db *gorm.DB, l *zap.SugaredLogger, k analysisCacheKey) (AnalyzeResponse, bool) {
 	var row AnalysisCache
 	err := db.Where("game_id = ? AND level = ? AND style = ? AND time_limit_ns = ? AND game_version = ?",
@@ -196,9 +190,8 @@ func loadAnalysisCache(db *gorm.DB, l *zap.SugaredLogger, k analysisCacheKey) (A
 	}, true
 }
 
-// saveAnalysisCache writes a result into the cache. Failures are logged
-// but not propagated — caching is best-effort. Uses ON CONFLICT DO
-// NOTHING so concurrent misses don't error on the unique index.
+// saveAnalysisCache is best-effort; concurrent misses can race so writes
+// use ON CONFLICT DO NOTHING.
 func saveAnalysisCache(db *gorm.DB, l *zap.SugaredLogger, k analysisCacheKey, agreed int, moves []MoveAnalysis) {
 	encoded, err := json.Marshal(moves)
 	if err != nil {

--- a/cmd/server/analyze.go
+++ b/cmd/server/analyze.go
@@ -8,11 +8,15 @@ import (
 	"net/http"
 	"time"
 
+	"fmt"
+
 	"github.com/go-chi/chi/v5"
 	"github.com/icco/gotak"
 	"github.com/icco/gotak/ai"
 	"github.com/icco/gutil/logging"
 	"go.uber.org/zap"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // defaultAnalyzeTimeLimit is the per-move budget the engine gets when the
@@ -98,23 +102,122 @@ func postAnalyzeHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	cfg, levelName := analyzeConfigFromRequest(req)
-	moves := analyzeGame(ctx, &ai.TakticianEngine{}, game, cfg)
-
-	resp := AnalyzeResponse{
-		Slug:      slug,
-		Size:      game.Board.Size,
-		Level:     levelName,
-		Moves:     moves,
-		MoveCount: len(moves),
+	key := analysisCacheKey{
+		gameID:      game.ID,
+		level:       levelName,
+		style:       string(cfg.Style),
+		timeLimitNs: int64(cfg.TimeLimit),
+		gameVersion: gameCacheVersion(game),
 	}
+
+	if cached, ok := loadAnalysisCache(db, l, key); ok {
+		writeAnalyzeResponse(w, l, slug, game.Board.Size, levelName, cached)
+		return
+	}
+
+	moves := analyzeGame(ctx, &ai.TakticianEngine{}, game, cfg)
+	agreed := 0
 	for _, m := range moves {
 		if m.Agreed {
-			resp.Agreed++
+			agreed++
 		}
 	}
 
+	saveAnalysisCache(db, l, key, agreed, moves)
+
+	writeAnalyzeResponse(w, l, slug, game.Board.Size, levelName, AnalyzeResponse{
+		Moves:     moves,
+		MoveCount: len(moves),
+		Agreed:    agreed,
+	})
+}
+
+// writeAnalyzeResponse fills the shared envelope fields and renders.
+func writeAnalyzeResponse(w http.ResponseWriter, l *zap.SugaredLogger, slug string, size int64, level string, resp AnalyzeResponse) {
+	resp.Slug = slug
+	resp.Size = size
+	resp.Level = level
 	if err := Renderer.JSON(w, http.StatusOK, resp); err != nil {
 		l.Errorw("failed to render analyze response", zap.Error(err))
+	}
+}
+
+// gameCacheVersion is a fingerprint of the game state used as part of
+// the analysis cache key. Today it's just the half-turn count, which
+// invalidates the cache when a game grows. The string layout leaves
+// room to mix in g.UpdatedAt or a content hash later if edit-in-place
+// becomes possible.
+func gameCacheVersion(g *gotak.Game) string {
+	count := 0
+	for _, t := range g.Turns {
+		if t == nil {
+			continue
+		}
+		if t.First != nil {
+			count++
+		}
+		if t.Second != nil {
+			count++
+		}
+	}
+	return fmt.Sprintf("v1:moves=%d", count)
+}
+
+// analysisCacheKey is the composite key used to look up a stored result.
+type analysisCacheKey struct {
+	gameID      int64
+	level       string
+	style       string
+	timeLimitNs int64
+	gameVersion string
+}
+
+// loadAnalysisCache returns a cached analysis result for the given key.
+// ok=false means cache miss. Real DB errors (other than "not found") are
+// logged so a flaky cache is at least observable.
+func loadAnalysisCache(db *gorm.DB, l *zap.SugaredLogger, k analysisCacheKey) (AnalyzeResponse, bool) {
+	var row AnalysisCache
+	err := db.Where("game_id = ? AND level = ? AND style = ? AND time_limit_ns = ? AND game_version = ?",
+		k.gameID, k.level, k.style, k.timeLimitNs, k.gameVersion).First(&row).Error
+	if err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			l.Warnw("analysis cache lookup failed", zap.Error(err))
+		}
+		return AnalyzeResponse{}, false
+	}
+	var moves []MoveAnalysis
+	if err := json.Unmarshal([]byte(row.Moves), &moves); err != nil {
+		l.Warnw("analysis cache row failed to decode", "id", row.ID, zap.Error(err))
+		return AnalyzeResponse{}, false
+	}
+	return AnalyzeResponse{
+		Moves:     moves,
+		MoveCount: len(moves),
+		Agreed:    row.Agreed,
+	}, true
+}
+
+// saveAnalysisCache writes a result into the cache. Failures are logged
+// but not propagated — caching is best-effort. Uses ON CONFLICT DO
+// NOTHING so concurrent misses don't error on the unique index.
+func saveAnalysisCache(db *gorm.DB, l *zap.SugaredLogger, k analysisCacheKey, agreed int, moves []MoveAnalysis) {
+	encoded, err := json.Marshal(moves)
+	if err != nil {
+		l.Warnw("could not encode analysis for cache", zap.Error(err))
+		return
+	}
+	row := AnalysisCache{
+		GameID:      k.gameID,
+		Level:       k.level,
+		Style:       k.style,
+		TimeLimitNs: k.timeLimitNs,
+		GameVersion: k.gameVersion,
+		Agreed:      agreed,
+		Moves:       string(encoded),
+	}
+	err = db.Clauses(clause.OnConflict{DoNothing: true}).Create(&row).Error
+	if err != nil {
+		l.Warnw("could not save analysis cache row", zap.Error(err))
 	}
 }
 

--- a/cmd/server/analyze_cache_test.go
+++ b/cmd/server/analyze_cache_test.go
@@ -74,8 +74,8 @@ func TestAnalysisCache_concurrentWritesNoError(t *testing.T) {
 	l := zap.NewNop().Sugar()
 	key := cacheKey(99, "advanced", "balanced", 2e9, "v1:moves=0")
 
-	// Second insert with the same key would violate the unique index;
-	// the OnConflict clause should turn it into a silent no-op.
+	// Two writes on the same key would violate the unique index without the
+	// ON CONFLICT clause.
 	saveAnalysisCache(db, l, key, 0, nil)
 	saveAnalysisCache(db, l, key, 0, nil)
 

--- a/cmd/server/analyze_cache_test.go
+++ b/cmd/server/analyze_cache_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/icco/gotak"
+	"go.uber.org/zap"
+)
+
+func cacheKey(gameID int64, level, style string, timeNs int64, version string) analysisCacheKey {
+	return analysisCacheKey{
+		gameID:      gameID,
+		level:       level,
+		style:       style,
+		timeLimitNs: timeNs,
+		gameVersion: version,
+	}
+}
+
+func TestAnalysisCache_roundTrip(t *testing.T) {
+	db := setupTestDB(t)
+	l := zap.NewNop().Sugar()
+
+	moves := []MoveAnalysis{
+		{Turn: 1, Player: gotak.PlayerWhite, Played: "a1", Best: "a1", Agreed: true},
+		{Turn: 1, Player: gotak.PlayerBlack, Played: "e5", Best: "d4", Agreed: false},
+	}
+	key := cacheKey(42, "advanced", "balanced", 2e9, "v1:moves=2")
+	saveAnalysisCache(db, l, key, 1, moves)
+
+	got, ok := loadAnalysisCache(db, l, key)
+	if !ok {
+		t.Fatal("expected cache hit immediately after save")
+	}
+	if got.Agreed != 1 {
+		t.Errorf("agreed = %d, want 1", got.Agreed)
+	}
+	if got.MoveCount != 2 {
+		t.Errorf("move count = %d, want 2", got.MoveCount)
+	}
+	if len(got.Moves) != 2 || got.Moves[1].Best != "d4" {
+		t.Errorf("moves = %+v, want round-trip of original", got.Moves)
+	}
+}
+
+func TestAnalysisCache_keyVariantsMiss(t *testing.T) {
+	db := setupTestDB(t)
+	l := zap.NewNop().Sugar()
+
+	base := cacheKey(42, "advanced", "balanced", 2e9, "v1:moves=2")
+	saveAnalysisCache(db, l, base, 0, nil)
+
+	cases := []struct {
+		name string
+		key  analysisCacheKey
+	}{
+		{"different game", cacheKey(43, "advanced", "balanced", 2e9, "v1:moves=2")},
+		{"different level", cacheKey(42, "expert", "balanced", 2e9, "v1:moves=2")},
+		{"different style", cacheKey(42, "advanced", "aggressive", 2e9, "v1:moves=2")},
+		{"different time limit", cacheKey(42, "advanced", "balanced", 5e9, "v1:moves=2")},
+		{"game grew", cacheKey(42, "advanced", "balanced", 2e9, "v1:moves=3")},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, ok := loadAnalysisCache(db, l, c.key); ok {
+				t.Errorf("%s should miss but hit", c.name)
+			}
+		})
+	}
+}
+
+func TestAnalysisCache_concurrentWritesNoError(t *testing.T) {
+	db := setupTestDB(t)
+	l := zap.NewNop().Sugar()
+	key := cacheKey(99, "advanced", "balanced", 2e9, "v1:moves=0")
+
+	// Second insert with the same key would violate the unique index;
+	// the OnConflict clause should turn it into a silent no-op.
+	saveAnalysisCache(db, l, key, 0, nil)
+	saveAnalysisCache(db, l, key, 0, nil)
+
+	if _, ok := loadAnalysisCache(db, l, key); !ok {
+		t.Errorf("cache hit expected after second save")
+	}
+}
+
+func TestGameCacheVersion_changesWithMoveCount(t *testing.T) {
+	g := playGame(t, 5, []scriptedMove{
+		{gotak.PlayerWhite, "a1"},
+	})
+	v1 := gameCacheVersion(g)
+	if err := g.DoSingleMove("e5", gotak.PlayerBlack); err != nil {
+		t.Fatal(err)
+	}
+	v2 := gameCacheVersion(g)
+	if v1 == v2 {
+		t.Errorf("game version did not change after a new move: %q", v1)
+	}
+}

--- a/cmd/server/analyze_test.go
+++ b/cmd/server/analyze_test.go
@@ -42,11 +42,11 @@ func TestGameBeforeMove_prefixesTurns(t *testing.T) {
 	})
 
 	cases := []struct {
-		name           string
-		turnIdx        int
-		isSecond       bool
-		wantTurns      int
-		wantSecondNil  bool // wantSecondNil applies to the last turn in the prefix
+		name          string
+		turnIdx       int
+		isSecond      bool
+		wantTurns     int
+		wantSecondNil bool // wantSecondNil applies to the last turn in the prefix
 	}{
 		{"before turn-1 first move", 0, false, 0, false},
 		{"before turn-1 second move", 0, true, 1, true},

--- a/cmd/server/models.go
+++ b/cmd/server/models.go
@@ -81,7 +81,27 @@ type User struct {
 	UpdatedAt    time.Time `json:"updated_at"`
 }
 
+// AnalysisCache stores the JSON-encoded result of a previous
+// postAnalyzeHandler call keyed by (game, engine config, game version)
+// so repeat requests against a stable game return immediately.
+// GameVersion is an opaque string fingerprint; today it encodes the
+// half-turn count, but the analyzer is free to add more (UpdatedAt, a
+// move-text hash) without a schema change.
+// `type:jsonb` is Postgres-native; SQLite (used in unit tests) silently
+// degrades it to TEXT, which is fine.
+type AnalysisCache struct {
+	ID          int64     `gorm:"primaryKey;autoIncrement" json:"id"`
+	GameID      int64     `gorm:"not null;uniqueIndex:idx_analysis_lookup,priority:1" json:"game_id"`
+	Level       string    `gorm:"type:varchar(16);not null;uniqueIndex:idx_analysis_lookup,priority:2" json:"level"`
+	Style       string    `gorm:"type:varchar(16);not null;uniqueIndex:idx_analysis_lookup,priority:3" json:"style"`
+	TimeLimitNs int64     `gorm:"not null;uniqueIndex:idx_analysis_lookup,priority:4" json:"time_limit_ns"`
+	GameVersion string    `gorm:"type:varchar(64);not null;uniqueIndex:idx_analysis_lookup,priority:5" json:"game_version"`
+	Agreed      int       `json:"agreed"`
+	Moves       string    `gorm:"type:jsonb" json:"moves"` // JSON-encoded []MoveAnalysis
+	CreatedAt   time.Time `json:"created_at"`
+}
+
 // AutoMigrate runs the database migrations
 func AutoMigrate(db *gorm.DB) error {
-	return db.AutoMigrate(&Game{}, &Tag{}, &Move{}, &User{})
+	return db.AutoMigrate(&Game{}, &Tag{}, &Move{}, &User{}, &AnalysisCache{})
 }

--- a/cmd/server/models.go
+++ b/cmd/server/models.go
@@ -81,14 +81,9 @@ type User struct {
 	UpdatedAt    time.Time `json:"updated_at"`
 }
 
-// AnalysisCache stores the JSON-encoded result of a previous
-// postAnalyzeHandler call keyed by (game, engine config, game version)
-// so repeat requests against a stable game return immediately.
-// GameVersion is an opaque string fingerprint; today it encodes the
-// half-turn count, but the analyzer is free to add more (UpdatedAt, a
-// move-text hash) without a schema change.
-// `type:jsonb` is Postgres-native; SQLite (used in unit tests) silently
-// degrades it to TEXT, which is fine.
+// AnalysisCache stores a previously computed analysis result.
+// GameVersion is an opaque fingerprint so its encoding can change
+// (UpdatedAt, content hash) without a schema change.
 type AnalysisCache struct {
 	ID          int64     `gorm:"primaryKey;autoIncrement" json:"id"`
 	GameID      int64     `gorm:"not null;uniqueIndex:idx_analysis_lookup,priority:1" json:"game_id"`


### PR DESCRIPTION
Refs #51. Adds an `AnalysisCache` table and a lookup-or-compute path on `POST /analyze/game/{slug}`. Cache key is `(game, level, style, time_limit, game_version)`; `game_version` is an opaque fingerprint that invalidates when the game changes. Writes use `ON CONFLICT DO NOTHING` so concurrent misses don't race.