### PR TITLE
feat: include move timestamps in replay

### DIFF
--- a/cmd/server/docs/docs.go
+++ b/cmd/server/docs/docs.go
@@ -1213,6 +1213,9 @@ const docTemplate = `{
                 "move": {
                     "type": "string"
                 },
+                "played_at": {
+                    "type": "string"
+                },
                 "player": {
                     "type": "integer"
                 },

--- a/cmd/server/docs/swagger.json
+++ b/cmd/server/docs/swagger.json
@@ -1207,6 +1207,9 @@
                 "move": {
                     "type": "string"
                 },
+                "played_at": {
+                    "type": "string"
+                },
                 "player": {
                     "type": "integer"
                 },

--- a/cmd/server/docs/swagger.yaml
+++ b/cmd/server/docs/swagger.yaml
@@ -239,6 +239,8 @@ definitions:
         type: object
       move:
         type: string
+      played_at:
+        type: string
       player:
         type: integer
       turn:

--- a/cmd/server/replay.go
+++ b/cmd/server/replay.go
@@ -12,13 +12,9 @@ import (
 	"gorm.io/gorm"
 )
 
-// ReplayStep is a single recorded position in a game replay. Each turn
-// produces up to two steps (one per player half-turn). Board is the
-// state immediately after Move was applied. PlayedAt is the server-side
-// timestamp from when the move was originally recorded; nil if unknown
-// (PTN-imported games, in-memory tests). A pointer is required for
-// omitempty to drop the field — `time.Time`'s zero value still
-// marshals as "0001-01-01T00:00:00Z".
+// ReplayStep is one half-turn's record. PlayedAt is a pointer so
+// omitempty drops it; encoding/json doesn't treat a zero time.Time as
+// empty.
 type ReplayStep struct {
 	Turn     int64                     `json:"turn"`
 	Player   int                       `json:"player"`
@@ -150,8 +146,8 @@ func loadGameForRead(w http.ResponseWriter, r *http.Request, l *zap.SugaredLogge
 	return game, ok
 }
 
-// loadGameForReadWithDB is the variant that also returns the open DB
-// handle, for callers that need extra queries (e.g. move timestamps).
+// loadGameForReadWithDB also returns the DB handle for callers that
+// need extra queries.
 func loadGameForReadWithDB(w http.ResponseWriter, r *http.Request, l *zap.SugaredLogger) (*gorm.DB, *gotak.Game, bool) {
 	ctx := r.Context()
 	db, err := getDB()
@@ -175,10 +171,8 @@ func loadGameForReadWithDB(w http.ResponseWriter, r *http.Request, l *zap.Sugare
 	return db, game, true
 }
 
-// loadMoveTimestamps returns CreatedAt for every Move of the game in the
-// same order the moves are replayed (turn ascending, then White before
-// Black). The returned slice length matches the number of recorded
-// half-turns; callers zip it against the replay step list.
+// loadMoveTimestamps returns CreatedAt for every Move in replay order
+// (turn ASC, then White before Black), ready to zip against ReplayStep.
 func loadMoveTimestamps(db *gorm.DB, gameID int64) ([]time.Time, error) {
 	var rows []struct {
 		Turn      int64
@@ -199,13 +193,9 @@ func loadMoveTimestamps(db *gorm.DB, gameID int64) ([]time.Time, error) {
 	return out, nil
 }
 
-// buildReplaySteps walks the game and applies each half-turn to a fresh
-// board, snapshotting the resulting state into a ReplayStep. moveTimes,
-// when non-nil, is zipped into the steps in order; a shorter slice
-// leaves trailing steps with a zero PlayedAt.
-//
-// We do not reuse game.Board (already populated by getGame's replayMoves
-// call) because we need every intermediate state, not just the final one.
+// buildReplaySteps replays the game on a fresh board, snapshotting after
+// each half-turn. moveTimes is zipped in if non-nil; a short slice
+// leaves trailing steps with nil PlayedAt.
 func buildReplaySteps(game *gotak.Game, moveTimes []time.Time) ([]ReplayStep, error) {
 	if game == nil || game.Board == nil {
 		return nil, nil

--- a/cmd/server/replay.go
+++ b/cmd/server/replay.go
@@ -3,21 +3,28 @@ package main
 import (
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/icco/gotak"
 	"github.com/icco/gutil/logging"
 	"go.uber.org/zap"
+	"gorm.io/gorm"
 )
 
 // ReplayStep is a single recorded position in a game replay. Each turn
 // produces up to two steps (one per player half-turn). Board is the
-// state immediately after Move was applied.
+// state immediately after Move was applied. PlayedAt is the server-side
+// timestamp from when the move was originally recorded; nil if unknown
+// (PTN-imported games, in-memory tests). A pointer is required for
+// omitempty to drop the field — `time.Time`'s zero value still
+// marshals as "0001-01-01T00:00:00Z".
 type ReplayStep struct {
-	Turn   int64                     `json:"turn"`
-	Player int                       `json:"player"`
-	Move   string                    `json:"move"`
-	Board  map[string][]*gotak.Stone `json:"board"`
+	Turn     int64                     `json:"turn"`
+	Player   int                       `json:"player"`
+	Move     string                    `json:"move"`
+	Board    map[string][]*gotak.Stone `json:"board"`
+	PlayedAt *time.Time                `json:"played_at,omitempty"`
 }
 
 // ReplayResponse is the payload returned by GET /game/{slug}/replay.
@@ -51,12 +58,19 @@ func getReplayHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	l := logging.FromContext(ctx)
 
-	game, ok := loadGameForRead(w, r, l)
+	db, game, ok := loadGameForReadWithDB(w, r, l)
 	if !ok {
 		return
 	}
 
-	steps, err := buildReplaySteps(game)
+	times, err := loadMoveTimestamps(db, game.ID)
+	if err != nil {
+		// Timestamps are nice-to-have; degrade rather than fail.
+		l.Warnw("could not load move timestamps", "slug", game.Slug, zap.Error(err))
+		times = nil
+	}
+
+	steps, err := buildReplaySteps(game, times)
 	if err != nil {
 		l.Errorw("could not build replay", "slug", game.Slug, zap.Error(err))
 		if jerr := Renderer.JSON(w, http.StatusInternalServerError, ErrorResponse{Error: "could not build replay"}); jerr != nil {
@@ -132,6 +146,13 @@ func getPositionHandler(w http.ResponseWriter, r *http.Request) {
 // read-only game endpoints. It writes the appropriate error response
 // itself; callers should bail when it returns ok=false.
 func loadGameForRead(w http.ResponseWriter, r *http.Request, l *zap.SugaredLogger) (*gotak.Game, bool) {
+	_, game, ok := loadGameForReadWithDB(w, r, l)
+	return game, ok
+}
+
+// loadGameForReadWithDB is the variant that also returns the open DB
+// handle, for callers that need extra queries (e.g. move timestamps).
+func loadGameForReadWithDB(w http.ResponseWriter, r *http.Request, l *zap.SugaredLogger) (*gorm.DB, *gotak.Game, bool) {
 	ctx := r.Context()
 	db, err := getDB()
 	if err != nil {
@@ -139,7 +160,7 @@ func loadGameForRead(w http.ResponseWriter, r *http.Request, l *zap.SugaredLogge
 		if jerr := Renderer.JSON(w, http.StatusInternalServerError, ErrorResponse{Error: "bad connection to db"}); jerr != nil {
 			l.Errorw("failed to render JSON", zap.Error(jerr))
 		}
-		return nil, false
+		return nil, nil, false
 	}
 
 	slug := ugcPolicy.Sanitize(chi.URLParamFromCtx(ctx, "slug"))
@@ -149,23 +170,57 @@ func loadGameForRead(w http.ResponseWriter, r *http.Request, l *zap.SugaredLogge
 		if jerr := Renderer.JSON(w, http.StatusNotFound, ErrorResponse{Error: "game not found"}); jerr != nil {
 			l.Errorw("failed to render JSON", zap.Error(jerr))
 		}
-		return nil, false
+		return nil, nil, false
 	}
-	return game, true
+	return db, game, true
+}
+
+// loadMoveTimestamps returns CreatedAt for every Move of the game in the
+// same order the moves are replayed (turn ascending, then White before
+// Black). The returned slice length matches the number of recorded
+// half-turns; callers zip it against the replay step list.
+func loadMoveTimestamps(db *gorm.DB, gameID int64) ([]time.Time, error) {
+	var rows []struct {
+		Turn      int64
+		Player    int
+		CreatedAt time.Time
+	}
+	if err := db.Model(&Move{}).
+		Select("turn, player, created_at").
+		Where("game_id = ?", gameID).
+		Order("turn ASC, player ASC").
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	out := make([]time.Time, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, r.CreatedAt)
+	}
+	return out, nil
 }
 
 // buildReplaySteps walks the game and applies each half-turn to a fresh
-// board, snapshotting the resulting state into a ReplayStep.
+// board, snapshotting the resulting state into a ReplayStep. moveTimes,
+// when non-nil, is zipped into the steps in order; a shorter slice
+// leaves trailing steps with a zero PlayedAt.
 //
 // We do not reuse game.Board (already populated by getGame's replayMoves
 // call) because we need every intermediate state, not just the final one.
-func buildReplaySteps(game *gotak.Game) ([]ReplayStep, error) {
+func buildReplaySteps(game *gotak.Game, moveTimes []time.Time) ([]ReplayStep, error) {
 	if game == nil || game.Board == nil {
 		return nil, nil
 	}
 	board := &gotak.Board{Size: game.Board.Size}
 	if err := board.Init(); err != nil {
 		return nil, err
+	}
+
+	timeAt := func(i int) *time.Time {
+		if i >= len(moveTimes) || moveTimes[i].IsZero() {
+			return nil
+		}
+		t := moveTimes[i]
+		return &t
 	}
 
 	steps := make([]ReplayStep, 0, len(game.Turns)*2)
@@ -178,10 +233,11 @@ func buildReplaySteps(game *gotak.Game) ([]ReplayStep, error) {
 				return nil, err
 			}
 			steps = append(steps, ReplayStep{
-				Turn:   turn.Number,
-				Player: gotak.PlayerWhite,
-				Move:   turn.First.Text,
-				Board:  snapshotSquares(board),
+				Turn:     turn.Number,
+				Player:   gotak.PlayerWhite,
+				Move:     turn.First.Text,
+				Board:    snapshotSquares(board),
+				PlayedAt: timeAt(len(steps)),
 			})
 		}
 		if turn.Second != nil {
@@ -189,10 +245,11 @@ func buildReplaySteps(game *gotak.Game) ([]ReplayStep, error) {
 				return nil, err
 			}
 			steps = append(steps, ReplayStep{
-				Turn:   turn.Number,
-				Player: gotak.PlayerBlack,
-				Move:   turn.Second.Text,
-				Board:  snapshotSquares(board),
+				Turn:     turn.Number,
+				Player:   gotak.PlayerBlack,
+				Move:     turn.Second.Text,
+				Board:    snapshotSquares(board),
+				PlayedAt: timeAt(len(steps)),
 			})
 		}
 	}

--- a/cmd/server/replay_test.go
+++ b/cmd/server/replay_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/icco/gotak"
 )
@@ -33,7 +36,7 @@ func TestBuildReplaySteps_emptyGame(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	steps, err := buildReplaySteps(g)
+	steps, err := buildReplaySteps(g, nil)
 	if err != nil {
 		t.Fatalf("buildReplaySteps: %v", err)
 	}
@@ -43,7 +46,7 @@ func TestBuildReplaySteps_emptyGame(t *testing.T) {
 }
 
 func TestBuildReplaySteps_nilGame(t *testing.T) {
-	steps, err := buildReplaySteps(nil)
+	steps, err := buildReplaySteps(nil, nil)
 	if err != nil {
 		t.Errorf("nil game should return (nil, nil), got err=%v", err)
 	}
@@ -60,7 +63,7 @@ func TestBuildReplaySteps_firstTurnInversion(t *testing.T) {
 		{gotak.PlayerBlack, "e5"},
 	})
 
-	steps, err := buildReplaySteps(g)
+	steps, err := buildReplaySteps(g, nil)
 	if err != nil {
 		t.Fatalf("buildReplaySteps: %v", err)
 	}
@@ -89,7 +92,7 @@ func TestBuildReplaySteps_snapshotsAreIndependent(t *testing.T) {
 		{gotak.PlayerBlack, "e5"},
 		{gotak.PlayerWhite, "b2"},
 	})
-	steps, err := buildReplaySteps(g)
+	steps, err := buildReplaySteps(g, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -264,5 +267,102 @@ func TestApplyHalfTurn_missingMoveIsNoop(t *testing.T) {
 	}
 	if err := applyHalfTurn(b, turn, true); err != nil {
 		t.Errorf("missing Second should be a no-op, got %v", err)
+	}
+}
+
+func TestBuildReplaySteps_zipsTimestamps(t *testing.T) {
+	g := playGame(t, 5, []scriptedMove{
+		{gotak.PlayerWhite, "a1"},
+		{gotak.PlayerBlack, "e5"},
+		{gotak.PlayerWhite, "b2"},
+	})
+	t0 := mustParseTime(t, "2026-01-01T00:00:00Z")
+	t1 := t0.Add(10 * time.Second)
+	t2 := t1.Add(15 * time.Second)
+	times := []time.Time{t0, t1, t2}
+
+	steps, err := buildReplaySteps(g, times)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(steps) != 3 {
+		t.Fatalf("want 3 steps, got %d", len(steps))
+	}
+	for i, want := range times {
+		if steps[i].PlayedAt == nil || !steps[i].PlayedAt.Equal(want) {
+			t.Errorf("step %d PlayedAt = %v, want %v", i, steps[i].PlayedAt, want)
+		}
+	}
+}
+
+func TestBuildReplaySteps_shortTimestampSlice(t *testing.T) {
+	g := playGame(t, 5, []scriptedMove{
+		{gotak.PlayerWhite, "a1"},
+		{gotak.PlayerBlack, "e5"},
+	})
+	t0 := mustParseTime(t, "2026-01-01T00:00:00Z")
+	steps, err := buildReplaySteps(g, []time.Time{t0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if steps[0].PlayedAt == nil || !steps[0].PlayedAt.Equal(t0) {
+		t.Errorf("step 0 PlayedAt = %v, want %v", steps[0].PlayedAt, t0)
+	}
+	if steps[1].PlayedAt != nil {
+		t.Errorf("step 1 should be nil, got %v", steps[1].PlayedAt)
+	}
+}
+
+func mustParseTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	v, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return v
+}
+
+func TestLoadMoveTimestamps(t *testing.T) {
+	db := setupTestDB(t)
+
+	// Insert three moves: turn 1 white, turn 1 black, turn 2 white.
+	moves := []Move{
+		{GameID: 7, Turn: 1, Player: gotak.PlayerWhite, Text: "a1"},
+		{GameID: 7, Turn: 1, Player: gotak.PlayerBlack, Text: "e5"},
+		{GameID: 7, Turn: 2, Player: gotak.PlayerWhite, Text: "b2"},
+	}
+	for i := range moves {
+		if err := db.Create(&moves[i]).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := loadMoveTimestamps(db, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d timestamps, want 3", len(got))
+	}
+	// CreatedAt is set by GORM on insert; just assert ascending and non-zero.
+	for i, ts := range got {
+		if ts.IsZero() {
+			t.Errorf("timestamp %d is zero", i)
+		}
+	}
+}
+
+func TestReplayStep_zeroPlayedAtIsOmitted(t *testing.T) {
+	g := playGame(t, 5, []scriptedMove{{gotak.PlayerWhite, "a1"}})
+	steps, err := buildReplaySteps(g, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, err := json.Marshal(steps[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(payload), "played_at") {
+		t.Errorf("played_at should be omitted when nil, got: %s", payload)
 	}
 }

--- a/cmd/server/replay_test.go
+++ b/cmd/server/replay_test.go
@@ -325,14 +325,20 @@ func mustParseTime(t *testing.T, s string) time.Time {
 func TestLoadMoveTimestamps(t *testing.T) {
 	db := setupTestDB(t)
 
-	// Insert three moves: turn 1 white, turn 1 black, turn 2 white.
-	moves := []Move{
-		{GameID: 7, Turn: 1, Player: gotak.PlayerWhite, Text: "a1"},
-		{GameID: 7, Turn: 1, Player: gotak.PlayerBlack, Text: "e5"},
-		{GameID: 7, Turn: 2, Player: gotak.PlayerWhite, Text: "b2"},
+	// Insert in reverse turn order with distinct sentinel CreatedAt values
+	// so the returned sequence proves the (turn ASC, player ASC) ordering
+	// rather than coincidentally matching insertion order.
+	tWhiteTurn1 := mustParseTime(t, "2026-01-01T00:00:00Z")
+	tBlackTurn1 := mustParseTime(t, "2026-01-02T00:00:00Z")
+	tWhiteTurn2 := mustParseTime(t, "2026-01-03T00:00:00Z")
+
+	rows := []Move{
+		{GameID: 7, Turn: 2, Player: gotak.PlayerWhite, Text: "b2", CreatedAt: tWhiteTurn2},
+		{GameID: 7, Turn: 1, Player: gotak.PlayerBlack, Text: "e5", CreatedAt: tBlackTurn1},
+		{GameID: 7, Turn: 1, Player: gotak.PlayerWhite, Text: "a1", CreatedAt: tWhiteTurn1},
 	}
-	for i := range moves {
-		if err := db.Create(&moves[i]).Error; err != nil {
+	for i := range rows {
+		if err := db.Create(&rows[i]).Error; err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -341,13 +347,13 @@ func TestLoadMoveTimestamps(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(got) != 3 {
-		t.Fatalf("got %d timestamps, want 3", len(got))
+	want := []time.Time{tWhiteTurn1, tBlackTurn1, tWhiteTurn2}
+	if len(got) != len(want) {
+		t.Fatalf("got %d timestamps, want %d", len(got), len(want))
 	}
-	// CreatedAt is set by GORM on insert; just assert ascending and non-zero.
-	for i, ts := range got {
-		if ts.IsZero() {
-			t.Errorf("timestamp %d is zero", i)
+	for i, w := range want {
+		if !got[i].Equal(w) {
+			t.Errorf("timestamp %d = %v, want %v", i, got[i], w)
 		}
 	}
 }


### PR DESCRIPTION
Refs #45. Each `ReplayStep` now carries a `played_at` populated from the `moves.created_at` column. Nil when unknown (PTN imports, tests). A timestamp-load failure logs a warning and degrades to no timestamps rather than failing the whole response.