### PR TITLE
feat: opening-line lookup endpoint

### DIFF
--- a/cmd/server/docs/docs.go
+++ b/cmd/server/docs/docs.go
@@ -119,7 +119,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "example": "\"a1,e5\"",
+                        "example": "a1,e5",
                         "description": "Comma-separated PTN moves",
                         "name": "prefix",
                         "in": "query"

--- a/cmd/server/docs/docs.go
+++ b/cmd/server/docs/docs.go
@@ -103,6 +103,50 @@ const docTemplate = `{
                 }
             }
         },
+        "/analyze/openings": {
+            "get": {
+                "description": "Given a prefix of moves (in PTN order — White on turn 1\nfirst, Black second, then alternating), returns the count\nof stored games matching the prefix and the frequency of\nmoves played in the next half-turn. Empty prefix lists\nfirst-move distribution across all games.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "analysis"
+                ],
+                "summary": "Look up opening continuations",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "example": "\"a1,e5\"",
+                        "description": "Comma-separated PTN moves",
+                        "name": "prefix",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/main.OpeningsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/confirm-reset": {
             "post": {
                 "description": "Reset password with token",
@@ -1138,6 +1182,37 @@ const docTemplate = `{
                 "turn": {
                     "type": "integer",
                     "example": 1
+                }
+            }
+        },
+        "main.OpeningContinuation": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "move": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.OpeningsResponse": {
+            "type": "object",
+            "properties": {
+                "continuations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/main.OpeningContinuation"
+                    }
+                },
+                "game_count": {
+                    "type": "integer"
+                },
+                "prefix": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },

--- a/cmd/server/docs/swagger.json
+++ b/cmd/server/docs/swagger.json
@@ -113,7 +113,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "example": "\"a1,e5\"",
+                        "example": "a1,e5",
                         "description": "Comma-separated PTN moves",
                         "name": "prefix",
                         "in": "query"

--- a/cmd/server/docs/swagger.json
+++ b/cmd/server/docs/swagger.json
@@ -97,6 +97,50 @@
                 }
             }
         },
+        "/analyze/openings": {
+            "get": {
+                "description": "Given a prefix of moves (in PTN order — White on turn 1\nfirst, Black second, then alternating), returns the count\nof stored games matching the prefix and the frequency of\nmoves played in the next half-turn. Empty prefix lists\nfirst-move distribution across all games.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "analysis"
+                ],
+                "summary": "Look up opening continuations",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "example": "\"a1,e5\"",
+                        "description": "Comma-separated PTN moves",
+                        "name": "prefix",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/main.OpeningsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/main.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/auth/confirm-reset": {
             "post": {
                 "description": "Reset password with token",
@@ -1132,6 +1176,37 @@
                 "turn": {
                     "type": "integer",
                     "example": 1
+                }
+            }
+        },
+        "main.OpeningContinuation": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "move": {
+                    "type": "string"
+                }
+            }
+        },
+        "main.OpeningsResponse": {
+            "type": "object",
+            "properties": {
+                "continuations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/main.OpeningContinuation"
+                    }
+                },
+                "game_count": {
+                    "type": "integer"
+                },
+                "prefix": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },

--- a/cmd/server/docs/swagger.yaml
+++ b/cmd/server/docs/swagger.yaml
@@ -191,6 +191,26 @@ definitions:
         example: 1
         type: integer
     type: object
+  main.OpeningContinuation:
+    properties:
+      count:
+        type: integer
+      move:
+        type: string
+    type: object
+  main.OpeningsResponse:
+    properties:
+      continuations:
+        items:
+          $ref: '#/definitions/main.OpeningContinuation'
+        type: array
+      game_count:
+        type: integer
+      prefix:
+        items:
+          type: string
+        type: array
+    type: object
   main.PositionResponse:
     properties:
       board:
@@ -344,6 +364,40 @@ paths:
           schema:
             $ref: '#/definitions/main.ErrorResponse'
       summary: Analyze a game move-by-move
+      tags:
+      - analysis
+  /analyze/openings:
+    get:
+      consumes:
+      - application/json
+      description: |-
+        Given a prefix of moves (in PTN order — White on turn 1
+        first, Black second, then alternating), returns the count
+        of stored games matching the prefix and the frequency of
+        moves played in the next half-turn. Empty prefix lists
+        first-move distribution across all games.
+      parameters:
+      - description: Comma-separated PTN moves
+        example: '"a1,e5"'
+        in: query
+        name: prefix
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/main.OpeningsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/main.ErrorResponse'
+      summary: Look up opening continuations
       tags:
       - analysis
   /auth/confirm-reset:

--- a/cmd/server/docs/swagger.yaml
+++ b/cmd/server/docs/swagger.yaml
@@ -378,7 +378,7 @@ paths:
         first-move distribution across all games.
       parameters:
       - description: Comma-separated PTN moves
-        example: '"a1,e5"'
+        example: a1,e5
         in: query
         name: prefix
         type: string

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -195,6 +195,7 @@ func buildRouter(opts routerOptions) http.Handler {
 		r.Get("/game/{slug}/position/{turn}", getPositionHandler)
 		r.Get("/game/{slug}/{turn}", getTurnHandler)
 		r.Post("/analyze/game/{slug}", postAnalyzeHandler)
+		r.Get("/analyze/openings", getOpeningsHandler)
 
 		r.Group(func(r chi.Router) {
 			r.Use(authMiddleware)

--- a/cmd/server/openings.go
+++ b/cmd/server/openings.go
@@ -32,7 +32,7 @@ type OpeningsResponse struct {
 // @Tags analysis
 // @Accept json
 // @Produce json
-// @Param prefix query string false "Comma-separated PTN moves" example("a1,e5")
+// @Param prefix query string false "Comma-separated PTN moves" example(a1,e5)
 // @Success 200 {object} OpeningsResponse
 // @Failure 400 {object} ErrorResponse
 // @Failure 500 {object} ErrorResponse

--- a/cmd/server/openings.go
+++ b/cmd/server/openings.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/icco/gotak"
+	"github.com/icco/gutil/logging"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+// OpeningContinuation is one move that has been played after a given prefix.
+type OpeningContinuation struct {
+	Move  string `json:"move"`
+	Count int    `json:"count"`
+}
+
+// OpeningsResponse is the payload returned by GET /analyze/openings.
+// Continuations are sorted by Count desc; ties broken alphabetically.
+type OpeningsResponse struct {
+	Prefix        []string              `json:"prefix"`
+	GameCount     int                   `json:"game_count"`
+	Continuations []OpeningContinuation `json:"continuations"`
+}
+
+// @Summary Look up opening continuations
+// @Description Given a prefix of moves (in PTN order — White on turn 1
+// @Description first, Black second, then alternating), returns the count
+// @Description of stored games matching the prefix and the frequency of
+// @Description moves played in the next half-turn. Empty prefix lists
+// @Description first-move distribution across all games.
+// @Tags analysis
+// @Accept json
+// @Produce json
+// @Param prefix query string false "Comma-separated PTN moves" example("a1,e5")
+// @Success 200 {object} OpeningsResponse
+// @Failure 400 {object} ErrorResponse
+// @Failure 500 {object} ErrorResponse
+// @Router /analyze/openings [get]
+func getOpeningsHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	l := logging.FromContext(ctx)
+
+	prefix, err := parseOpeningPrefix(r.URL.Query().Get("prefix"))
+	if err != nil {
+		l.Warnw("invalid opening prefix", zap.Error(err))
+		if jerr := Renderer.JSON(w, http.StatusBadRequest, ErrorResponse{Error: err.Error()}); jerr != nil {
+			l.Errorw("failed to render JSON", zap.Error(jerr))
+		}
+		return
+	}
+
+	db, err := getDB()
+	if err != nil {
+		l.Errorw("could not get db", zap.Error(err))
+		if jerr := Renderer.JSON(w, http.StatusInternalServerError, ErrorResponse{Error: "bad connection to db"}); jerr != nil {
+			l.Errorw("failed to render JSON", zap.Error(jerr))
+		}
+		return
+	}
+
+	count, conts, err := computeOpenings(db, prefix)
+	if err != nil {
+		l.Errorw("could not compute openings", zap.Error(err))
+		if jerr := Renderer.JSON(w, http.StatusInternalServerError, ErrorResponse{Error: "could not compute openings"}); jerr != nil {
+			l.Errorw("failed to render JSON", zap.Error(jerr))
+		}
+		return
+	}
+
+	resp := OpeningsResponse{
+		Prefix:        prefix,
+		GameCount:     count,
+		Continuations: conts,
+	}
+	if err := Renderer.JSON(w, http.StatusOK, resp); err != nil {
+		l.Errorw("failed to render openings response", zap.Error(err))
+	}
+}
+
+// parseOpeningPrefix splits the comma-separated query value and validates
+// each entry as a syntactically-valid PTN move. The returned strings come
+// from the parsed Move so they match how moves are stored in the DB
+// (annotations like `!`/`?` stripped).
+func parseOpeningPrefix(raw string) ([]string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		mv, err := gotak.NewMove(p)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, mv.Text)
+	}
+	return out, nil
+}
+
+// computeOpenings is an in-memory aggregation over the Move table. Move
+// past a few thousand games to a SQL CTE.
+func computeOpenings(db *gorm.DB, prefix []string) (int, []OpeningContinuation, error) {
+	var rows []Move
+	if err := db.Model(&Move{}).
+		Order("game_id ASC, turn ASC, player ASC").
+		Find(&rows).Error; err != nil {
+		return 0, nil, err
+	}
+
+	byGame := map[int64][]string{}
+	for _, r := range rows {
+		byGame[r.GameID] = append(byGame[r.GameID], r.Text)
+	}
+
+	count := 0
+	contCounts := map[string]int{}
+	for _, moves := range byGame {
+		if len(moves) < len(prefix) {
+			continue
+		}
+		match := true
+		for i, p := range prefix {
+			if moves[i] != p {
+				match = false
+				break
+			}
+		}
+		if !match {
+			continue
+		}
+		count++
+		if len(moves) > len(prefix) {
+			contCounts[moves[len(prefix)]]++
+		}
+	}
+
+	conts := make([]OpeningContinuation, 0, len(contCounts))
+	for m, c := range contCounts {
+		conts = append(conts, OpeningContinuation{Move: m, Count: c})
+	}
+	sort.Slice(conts, func(i, j int) bool {
+		if conts[i].Count != conts[j].Count {
+			return conts[i].Count > conts[j].Count
+		}
+		return conts[i].Move < conts[j].Move
+	})
+	return count, conts, nil
+}

--- a/cmd/server/openings.go
+++ b/cmd/server/openings.go
@@ -11,14 +11,12 @@ import (
 	"gorm.io/gorm"
 )
 
-// OpeningContinuation is one move that has been played after a given prefix.
 type OpeningContinuation struct {
 	Move  string `json:"move"`
 	Count int    `json:"count"`
 }
 
-// OpeningsResponse is the payload returned by GET /analyze/openings.
-// Continuations are sorted by Count desc; ties broken alphabetically.
+// OpeningsResponse continuations are sorted by Count desc, then Move asc.
 type OpeningsResponse struct {
 	Prefix        []string              `json:"prefix"`
 	GameCount     int                   `json:"game_count"`
@@ -80,10 +78,8 @@ func getOpeningsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// parseOpeningPrefix splits the comma-separated query value and validates
-// each entry as a syntactically-valid PTN move. The returned strings come
-// from the parsed Move so they match how moves are stored in the DB
-// (annotations like `!`/`?` stripped).
+// parseOpeningPrefix returns moves canonicalised through gotak.NewMove
+// so PTN annotations (`!`, `?`) match how the DB stores them.
 func parseOpeningPrefix(raw string) ([]string, error) {
 	if strings.TrimSpace(raw) == "" {
 		return nil, nil
@@ -104,8 +100,8 @@ func parseOpeningPrefix(raw string) ([]string, error) {
 	return out, nil
 }
 
-// computeOpenings is an in-memory aggregation over the Move table. Move
-// past a few thousand games to a SQL CTE.
+// computeOpenings does the aggregation in Go; move to a SQL CTE once
+// the Move table grows past a few thousand rows.
 func computeOpenings(db *gorm.DB, prefix []string) (int, []OpeningContinuation, error) {
 	var rows []Move
 	if err := db.Model(&Move{}).

--- a/cmd/server/openings_test.go
+++ b/cmd/server/openings_test.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/icco/gotak"
+)
+
+func TestParseOpeningPrefix(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    []string
+		wantErr bool
+	}{
+		{"", nil, false},
+		{"   ", nil, false},
+		{"a1", []string{"a1"}, false},
+		{"a1,e5,Sb2", []string{"a1", "e5", "Sb2"}, false},
+		{" a1 , e5 ", []string{"a1", "e5"}, false},
+		{"a1,,e5", []string{"a1", "e5"}, false},
+		{"not-a-move", nil, true},
+		{"a1,nonsense", nil, true},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got, err := parseOpeningPrefix(c.in)
+			if (err != nil) != c.wantErr {
+				t.Fatalf("err = %v, wantErr = %v", err, c.wantErr)
+			}
+			if c.wantErr {
+				return
+			}
+			if len(got) != len(c.want) {
+				t.Fatalf("got %v, want %v", got, c.want)
+			}
+			for i := range got {
+				if got[i] != c.want[i] {
+					t.Errorf("got[%d] = %q, want %q", i, got[i], c.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestComputeOpenings(t *testing.T) {
+	db := setupTestDB(t)
+
+	// Three games:
+	//   1: a1, e5, b2, d4
+	//   2: a1, e5, c3, d4
+	//   3: a1, a5, b2 (diverges immediately on move 2)
+	seed := []struct {
+		gameID  int64
+		turn    int64
+		player  int
+		text    string
+	}{
+		{1, 1, gotak.PlayerWhite, "a1"},
+		{1, 1, gotak.PlayerBlack, "e5"},
+		{1, 2, gotak.PlayerWhite, "b2"},
+		{1, 2, gotak.PlayerBlack, "d4"},
+		{2, 1, gotak.PlayerWhite, "a1"},
+		{2, 1, gotak.PlayerBlack, "e5"},
+		{2, 2, gotak.PlayerWhite, "c3"},
+		{2, 2, gotak.PlayerBlack, "d4"},
+		{3, 1, gotak.PlayerWhite, "a1"},
+		{3, 1, gotak.PlayerBlack, "a5"},
+		{3, 2, gotak.PlayerWhite, "b2"},
+	}
+	for _, s := range seed {
+		if err := db.Create(&Move{GameID: s.gameID, Turn: s.turn, Player: s.player, Text: s.text}).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("empty prefix: all games, first-move distribution", func(t *testing.T) {
+		count, conts, err := computeOpenings(db, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count != 3 {
+			t.Errorf("game count = %d, want 3", count)
+		}
+		// All three games start with a1.
+		if len(conts) != 1 || conts[0].Move != "a1" || conts[0].Count != 3 {
+			t.Errorf("continuations = %+v, want [{a1 3}]", conts)
+		}
+	})
+
+	t.Run("prefix [a1]: 3 games, next-move split", func(t *testing.T) {
+		count, conts, err := computeOpenings(db, []string{"a1"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count != 3 {
+			t.Errorf("game count = %d, want 3", count)
+		}
+		// 2x e5, 1x a5 — sorted by count desc, then alphabetical.
+		want := []OpeningContinuation{{Move: "e5", Count: 2}, {Move: "a5", Count: 1}}
+		if len(conts) != len(want) {
+			t.Fatalf("got %+v, want %+v", conts, want)
+		}
+		for i, w := range want {
+			if conts[i] != w {
+				t.Errorf("conts[%d] = %+v, want %+v", i, conts[i], w)
+			}
+		}
+	})
+
+	t.Run("prefix [a1, e5]: 2 games, next-move split", func(t *testing.T) {
+		count, conts, err := computeOpenings(db, []string{"a1", "e5"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count != 2 {
+			t.Errorf("game count = %d, want 2", count)
+		}
+		want := []OpeningContinuation{{Move: "b2", Count: 1}, {Move: "c3", Count: 1}}
+		if len(conts) != len(want) {
+			t.Fatalf("got %+v, want %+v", conts, want)
+		}
+		for i, w := range want {
+			if conts[i] != w {
+				t.Errorf("conts[%d] = %+v, want %+v", i, conts[i], w)
+			}
+		}
+	})
+
+	t.Run("no matching games", func(t *testing.T) {
+		count, conts, err := computeOpenings(db, []string{"e3"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count != 0 {
+			t.Errorf("game count = %d, want 0", count)
+		}
+		if len(conts) != 0 {
+			t.Errorf("continuations = %+v, want empty", conts)
+		}
+	})
+
+	t.Run("prefix longer than any game produces zero matches", func(t *testing.T) {
+		count, _, err := computeOpenings(db, []string{"a1", "e5", "b2", "d4", "extra"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count != 0 {
+			t.Errorf("game count = %d, want 0", count)
+		}
+	})
+
+	t.Run("prefix matching a game exactly produces no continuations", func(t *testing.T) {
+		count, conts, err := computeOpenings(db, []string{"a1", "e5", "b2", "d4"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count != 1 {
+			t.Errorf("game count = %d, want 1", count)
+		}
+		if len(conts) != 0 {
+			t.Errorf("continuations = %+v, want empty (game ended at the prefix)", conts)
+		}
+	})
+}


### PR DESCRIPTION
Refs #51. `GET /analyze/openings?prefix=a1,e5` returns the count of stored games matching the move prefix plus the frequency of moves played next. Empty prefix lists the first-move distribution across all games. In-memory aggregation today; flagged for SQL migration once the Move table grows.