### PR TITLE
fix: address golangci-lint findings

### DIFF
--- a/ai/engine.go
+++ b/ai/engine.go
@@ -1,3 +1,4 @@
+// Package ai provides AI engines for playing the Tak board game.
 package ai
 
 import (
@@ -23,6 +24,7 @@ var (
 // DifficultyLevel represents AI strength.
 type DifficultyLevel int
 
+// Difficulty levels for the AI, from weakest to strongest.
 const (
 	Beginner DifficultyLevel = iota
 	Intermediate
@@ -33,6 +35,7 @@ const (
 // Style represents AI playing style.
 type Style string
 
+// Known AI playing styles.
 const (
 	Aggressive Style = "aggressive"
 	Defensive  Style = "defensive"
@@ -40,6 +43,8 @@ const (
 )
 
 // AIConfig holds configuration for an AI player.
+//
+//revive:disable-next-line:exported // AIConfig is referenced widely across packages; renaming would be a breaking change.
 type AIConfig struct {
 	Level       DifficultyLevel
 	Style       Style
@@ -56,6 +61,7 @@ type Engine interface {
 // TakticianEngine wraps the Taktician AI library
 type TakticianEngine struct{}
 
+// GetMove returns the engine's chosen move for the given game state, formatted as a PTN string.
 func (e *TakticianEngine) GetMove(ctx context.Context, g *gotak.Game, cfg AIConfig) (string, error) {
 	// Ensure board size is within expected bounds (Tak standard: 3 - 9)
 	if g.Board.Size < 3 || g.Board.Size > 9 {
@@ -106,7 +112,8 @@ func (e *TakticianEngine) GetMove(ctx context.Context, g *gotak.Game, cfg AIConf
 	return ptnMove, nil
 }
 
-func (e *TakticianEngine) ExplainMove(ctx context.Context, g *gotak.Game, cfg AIConfig) (string, error) {
+// ExplainMove returns a human-readable description of how the engine arrived at its move.
+func (e *TakticianEngine) ExplainMove(_ context.Context, _ *gotak.Game, cfg AIConfig) (string, error) {
 	return fmt.Sprintf("AI move generated using %v level with %v style", cfg.Level, cfg.Style), nil
 }
 
@@ -300,7 +307,7 @@ func convertStringToMove(moveStr string, boardSize int) (tak.Move, error) {
 		} else {
 			// Default: drop all stones one by one
 			drops := make([]int, count)
-			for i := 0; i < count; i++ {
+			for i := range count {
 				drops[i] = 1
 			}
 			slides = tak.MkSlides(drops...)

--- a/board.go
+++ b/board.go
@@ -1,3 +1,5 @@
+// Package gotak implements the Tak board game: board, stones, moves, games,
+// PTN parsing, and TPS serialization.
 package gotak
 
 import (
@@ -21,7 +23,7 @@ type SquareFunc func(string, []*Stone) error
 // function returns.
 func (b *Board) IterateOverSquares(f SquareFunc) error {
 	letters := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"}
-	for x := int64(0); x < b.Size; x++ {
+	for x := range b.Size {
 		for y := int64(1); y <= b.Size; y++ {
 			location := letters[x] + strconv.FormatInt(y, 10)
 			err := f(location, b.Squares[location])
@@ -41,7 +43,7 @@ func (b *Board) Init() error {
 	}
 
 	b.Squares = map[string][]*Stone{}
-	_ = b.IterateOverSquares(func(l string, s []*Stone) error {
+	_ = b.IterateOverSquares(func(l string, _ []*Stone) error {
 		b.Squares[l] = []*Stone{}
 		return nil
 	})
@@ -278,7 +280,7 @@ func (b *Board) DoMove(mv *Move, player int) error {
 		squares := []string{}
 		currentSpace := mv.Square
 
-		for i := 0; i < len(mv.MoveDropCounts); i++ {
+		for range len(mv.MoveDropCounts) {
 			nextSpace := Translate(currentSpace, mv.MoveDirection)
 
 			// Validate next space is on board
@@ -295,7 +297,7 @@ func (b *Board) DoMove(mv *Move, player int) error {
 		for i, targetSquare := range squares {
 			dropCount := mv.MoveDropCounts[i]
 
-			for j := int64(0); j < dropCount; j++ {
+			for range dropCount {
 				if stoneIndex >= int64(len(stones)) {
 					return fmt.Errorf("not enough stones to drop")
 				}

--- a/board_test.go
+++ b/board_test.go
@@ -82,7 +82,7 @@ func TestMoving(t *testing.T) {
 		})
 	}
 
-	//t.Logf("squares post moves: %+v", b.Squares)
+	// t.Logf("squares post moves: %+v", b.Squares)
 
 	if len(b.Squares["b4"]) != 1 || len(b.Squares["c4"]) != 2 || len(b.Squares["d4"]) != 1 {
 		t.Errorf("pieces are not in the correct place: %+v", b.Squares)
@@ -119,7 +119,7 @@ func TestMovingOnce(t *testing.T) {
 		})
 	}
 
-	//t.Logf("squares post moves: %+v", b.Squares)
+	// t.Logf("squares post moves: %+v", b.Squares)
 
 	if len(b.Squares["a2"]) != 1 {
 		t.Errorf("pieces are not in the correct place: %+v", b.Squares)

--- a/cmd/gotak/main.go
+++ b/cmd/gotak/main.go
@@ -1,7 +1,9 @@
+// Package main is the gotak CLI: a terminal client for the Tak game server.
 package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -135,7 +137,9 @@ func loadTokenCache() (*TokenCache, error) {
 
 // validateToken checks if the cached token is still valid by making a test API call
 func validateToken(token, serverURL string) error {
-	req, err := http.NewRequest("GET", serverURL+"/auth/profile", nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, serverURL+"/auth/profile", nil)
 	if err != nil {
 		return err
 	}
@@ -595,9 +599,8 @@ func (m model) updateAuth(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 			if m.authMode == authModeLogin {
 				return m, m.loginUser()
-			} else {
-				return m, m.registerUser()
 			}
+			return m, m.registerUser()
 		}
 		return m, nil
 	}
@@ -1035,7 +1038,7 @@ func (m model) viewGame() string {
 
 	title := titleStyle.Width(m.width).Render(fmt.Sprintf("🎯 Game: %s", m.gameData.Slug))
 
-	boardSize := 0
+	var boardSize int
 	if m.gameData.Board != nil {
 		boardSize = int(m.gameData.Board.Size)
 	} else {
@@ -1115,7 +1118,7 @@ func (m model) renderBoard(size int) string {
 
 	// Top border
 	b.WriteString("   ┌")
-	for i := 0; i < size; i++ {
+	for i := range size {
 		b.WriteString(strings.Repeat("─", cellWidth))
 		if i < size-1 {
 			b.WriteString("┬")
@@ -1125,7 +1128,7 @@ func (m model) renderBoard(size int) string {
 
 	for row := size; row >= 1; row-- {
 		fmt.Fprintf(&b, " %d │", row)
-		for col := 0; col < size; col++ {
+		for col := range size {
 			sq := fmt.Sprintf("%c%d", 'a'+col, row)
 			b.WriteString(renderCell(squares[sq], cellWidth))
 			b.WriteString("│")
@@ -1134,7 +1137,7 @@ func (m model) renderBoard(size int) string {
 
 		if row > 1 {
 			b.WriteString("   ├")
-			for i := 0; i < size; i++ {
+			for i := range size {
 				b.WriteString(strings.Repeat("─", cellWidth))
 				if i < size-1 {
 					b.WriteString("┼")
@@ -1146,7 +1149,7 @@ func (m model) renderBoard(size int) string {
 
 	// Bottom border
 	b.WriteString("   └")
-	for i := 0; i < size; i++ {
+	for i := range size {
 		b.WriteString(strings.Repeat("─", cellWidth))
 		if i < size-1 {
 			b.WriteString("┴")
@@ -1154,7 +1157,7 @@ func (m model) renderBoard(size int) string {
 	}
 	b.WriteString("┘\n   ")
 
-	for col := 0; col < size; col++ {
+	for col := range size {
 		fmt.Fprintf(&b, "  %c  ", 'a'+col)
 		if col < size-1 {
 			b.WriteString(" ")
@@ -1254,7 +1257,7 @@ func (m model) requestAIMove() tea.Cmd {
 
 		data, _ := json.Marshal(payload)
 
-		req, _ := http.NewRequest("POST", m.serverURL+"/game/"+m.gameSlug+"/ai-move", bytes.NewBuffer(data))
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, m.serverURL+"/game/"+m.gameSlug+"/ai-move", bytes.NewBuffer(data))
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Authorization", "Bearer "+m.token)
 		req.Header.Set("User-Agent", fmt.Sprintf("gotak-cli %s", getVersion()))
@@ -1320,7 +1323,7 @@ func (m model) loginUser() tea.Cmd {
 		}
 
 		data, _ := json.Marshal(payload)
-		req, _ := http.NewRequest("POST", m.serverURL+"/auth/login", bytes.NewBuffer(data))
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, m.serverURL+"/auth/login", bytes.NewBuffer(data))
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("User-Agent", fmt.Sprintf("gotak-cli %s", getVersion()))
 
@@ -1371,7 +1374,7 @@ func (m model) registerUser() tea.Cmd {
 		}
 
 		data, _ := json.Marshal(payload)
-		req, _ := http.NewRequest("POST", m.serverURL+"/auth/register", bytes.NewBuffer(data))
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, m.serverURL+"/auth/register", bytes.NewBuffer(data))
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("User-Agent", fmt.Sprintf("gotak-cli %s", getVersion()))
 
@@ -1407,14 +1410,14 @@ func (m model) createGame() tea.Cmd {
 
 		data, _ := json.Marshal(payload)
 
-		req, _ := http.NewRequest("POST", m.serverURL+"/game/new", bytes.NewBuffer(data))
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, m.serverURL+"/game/new", bytes.NewBuffer(data))
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Authorization", "Bearer "+m.token)
 		req.Header.Set("User-Agent", fmt.Sprintf("gotak-cli %s", getVersion()))
 
 		// Don't follow redirects automatically
 		client := &http.Client{
-			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 				return http.ErrUseLastResponse
 			},
 		}
@@ -1440,7 +1443,7 @@ func (m model) createGame() tea.Cmd {
 			gameSlug := parts[2]
 
 			// Now fetch the game data with a GET request
-			getReq, _ := http.NewRequest("GET", m.serverURL+"/game/"+gameSlug, nil)
+			getReq, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, m.serverURL+"/game/"+gameSlug, nil)
 			getReq.Header.Set("Authorization", "Bearer "+m.token)
 			getReq.Header.Set("User-Agent", fmt.Sprintf("gotak-cli %s", getVersion()))
 
@@ -1487,7 +1490,7 @@ func (m model) submitMove() tea.Cmd {
 
 		data, _ := json.Marshal(payload)
 
-		req, _ := http.NewRequest("POST", m.serverURL+"/game/"+m.gameSlug+"/move", bytes.NewBuffer(data))
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, m.serverURL+"/game/"+m.gameSlug+"/move", bytes.NewBuffer(data))
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Authorization", "Bearer "+m.token)
 		req.Header.Set("User-Agent", fmt.Sprintf("gotak-cli %s", getVersion()))

--- a/cmd/parse-ptn/main.go
+++ b/cmd/parse-ptn/main.go
@@ -1,3 +1,5 @@
+// Package main implements the parse-ptn command-line tool, which parses a PTN
+// (Portable Tak Notation) file and prints the resulting game state.
 package main
 
 import (

--- a/cmd/server/ai.go
+++ b/cmd/server/ai.go
@@ -241,7 +241,7 @@ func PostAIMoveHandler(w http.ResponseWriter, r *http.Request) {
 
 	winner, gameOver := game.GameOver()
 	if gameOver {
-		err = updateGameStatus(db, game.Slug, "finished", winner)
+		err = updateGameStatus(db, game.Slug, winner)
 		if err != nil {
 			l.Errorw("could not update game status after AI move", zap.Error(err))
 		}

--- a/cmd/server/ai_e2e_test.go
+++ b/cmd/server/ai_e2e_test.go
@@ -689,7 +689,7 @@ func testAIServerSideHandlerWithDB(w http.ResponseWriter, r *http.Request, db *g
 	// Check if game is now over and update status
 	winner, gameOver := game.GameOver()
 	if gameOver {
-		err = updateGameStatus(db, game.Slug, "finished", winner)
+		err = updateGameStatus(db, game.Slug, winner)
 		if err != nil {
 			log.Errorw("could not update game status after AI move", zap.Error(err))
 		}
@@ -874,7 +874,7 @@ func testMoveHandlerWithTurnManagement(w http.ResponseWriter, r *http.Request, d
 	// Check if game is now over and update status
 	winner, gameOver := game.GameOver()
 	if gameOver {
-		err = updateGameStatus(db, game.Slug, "finished", winner)
+		err = updateGameStatus(db, game.Slug, winner)
 		if err != nil {
 			log.Errorw("could not update game status", zap.Error(err))
 		}
@@ -1024,7 +1024,7 @@ func newMoveHandlerWithDB(w http.ResponseWriter, r *http.Request, db *gorm.DB) {
 	// Check if game is now over and update status
 	winner, gameOver := game.GameOver()
 	if gameOver {
-		err = updateGameStatus(db, game.Slug, "finished", winner)
+		err = updateGameStatus(db, game.Slug, winner)
 		if err != nil {
 			log.Errorw("could not update game status", zap.Error(err))
 		}
@@ -1259,7 +1259,7 @@ func postAIMoveHandlerWithDB(w http.ResponseWriter, r *http.Request, db *gorm.DB
 	// Check if game is now over and update status
 	winner, gameOver := game.GameOver()
 	if gameOver {
-		err = updateGameStatus(db, game.Slug, "finished", winner)
+		err = updateGameStatus(db, game.Slug, winner)
 		if err != nil {
 			log.Errorw("could not update game status", zap.Error(err))
 		}

--- a/cmd/server/analyze_cache_test.go
+++ b/cmd/server/analyze_cache_test.go
@@ -85,7 +85,7 @@ func TestAnalysisCache_concurrentWritesNoError(t *testing.T) {
 }
 
 func TestGameCacheVersion_changesWithMoveCount(t *testing.T) {
-	g := playGame(t, 5, []scriptedMove{
+	g := playGame(t, []scriptedMove{
 		{gotak.PlayerWhite, "a1"},
 	})
 	v1 := gameCacheVersion(g)

--- a/cmd/server/analyze_test.go
+++ b/cmd/server/analyze_test.go
@@ -34,7 +34,7 @@ func (s *stubEngine) ExplainMove(_ context.Context, _ *gotak.Game, _ ai.AIConfig
 }
 
 func TestGameBeforeMove_prefixesTurns(t *testing.T) {
-	g := playGame(t, 5, []scriptedMove{
+	g := playGame(t, []scriptedMove{
 		{gotak.PlayerWhite, "a1"},
 		{gotak.PlayerBlack, "e5"},
 		{gotak.PlayerWhite, "b2"},
@@ -88,7 +88,7 @@ func TestGameBeforeMove_nilGame(t *testing.T) {
 }
 
 func TestAnalyzeGame_recordsAgreement(t *testing.T) {
-	g := playGame(t, 5, []scriptedMove{
+	g := playGame(t, []scriptedMove{
 		{gotak.PlayerWhite, "a1"},
 		{gotak.PlayerBlack, "e5"},
 		{gotak.PlayerWhite, "b2"},
@@ -141,7 +141,7 @@ func TestAnalyzeGame_emptyGame(t *testing.T) {
 }
 
 func TestAnalyzeGame_canceledContext(t *testing.T) {
-	g := playGame(t, 5, []scriptedMove{
+	g := playGame(t, []scriptedMove{
 		{gotak.PlayerWhite, "a1"},
 		{gotak.PlayerBlack, "e5"},
 	})

--- a/cmd/server/auth_pkgz.go
+++ b/cmd/server/auth_pkgz.go
@@ -72,7 +72,7 @@ func newAuthService() *auth2.Service {
 	}
 
 	service := auth2.NewService(auth2.Opts{
-		SecretReader:  token.SecretFunc(func(aud string) (string, error) { return secret, nil }),
+		SecretReader:  token.SecretFunc(func(_ string) (string, error) { return secret, nil }),
 		TokenDuration: 24 * time.Hour, // 1 day
 		Issuer:        issuer,
 		URL:           "https://gotak.app", // change for local/dev

--- a/cmd/server/auth_test.go
+++ b/cmd/server/auth_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
-	"golang.org/x/crypto/bcrypt"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"golang.org/x/crypto/bcrypt"
 )
 
 func TestUserModel(t *testing.T) {
@@ -145,7 +147,7 @@ func TestAuthMiddlewareWithoutUser(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	req := httptest.NewRequest("GET", "/test", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/test", nil)
 	w := httptest.NewRecorder()
 
 	handler.ServeHTTP(w, req)
@@ -210,7 +212,7 @@ func TestGameParticipationVerification(t *testing.T) {
 
 func TestMustUserFromContext(t *testing.T) {
 	// Test getMustUserFromContext with nil user (should panic)
-	req := httptest.NewRequest("GET", "/test", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/test", nil)
 
 	defer func() {
 		if r := recover(); r == nil {

--- a/cmd/server/database.go
+++ b/cmd/server/database.go
@@ -227,10 +227,10 @@ func replayMoves(game *gotak.Game) error {
 	return nil
 }
 
-// updateGameStatus updates the game status in the database
-func updateGameStatus(db *gorm.DB, slug, status string, winner int) error {
+// updateGameStatus marks the game as finished and records the winner.
+func updateGameStatus(db *gorm.DB, slug string, winner int) error {
 	result := db.Model(&Game{}).Where("slug = ?", slug).Updates(Game{
-		Status: status,
+		Status: "finished",
 		Winner: winner,
 	})
 	if result.Error != nil {

--- a/cmd/server/database_test.go
+++ b/cmd/server/database_test.go
@@ -257,7 +257,7 @@ func TestUpdateGameStatus(t *testing.T) {
 	}
 
 	// Test updating game status
-	err = updateGameStatus(db, slug, "finished", gotak.PlayerWhite)
+	err = updateGameStatus(db, slug, gotak.PlayerWhite)
 	if err != nil {
 		t.Fatalf("Failed to update game status: %v", err)
 	}
@@ -278,7 +278,7 @@ func TestUpdateGameStatus(t *testing.T) {
 	}
 
 	// Test updating non-existent game
-	err = updateGameStatus(db, "nonexistent", "finished", 1)
+	err = updateGameStatus(db, "nonexistent", 1)
 	if err == nil {
 		t.Error("Expected error when updating status for non-existent game")
 	}
@@ -382,7 +382,7 @@ func TestGameWorkflow(t *testing.T) {
 	}
 
 	// 6. Update game status
-	err = updateGameStatus(db, slug, "finished", gotak.PlayerWhite)
+	err = updateGameStatus(db, slug, gotak.PlayerWhite)
 	if err != nil {
 		t.Fatalf("Failed to update game status: %v", err)
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,3 +1,5 @@
+// Package main implements the gotak HTTP server, providing the REST API,
+// authentication, persistence, and AI endpoints for the Tak game.
 package main
 
 import (
@@ -630,7 +632,7 @@ func newMoveHandler(w http.ResponseWriter, r *http.Request) {
 
 	winner, gameOver = game.GameOver()
 	if gameOver {
-		err = updateGameStatus(db, game.Slug, "finished", winner)
+		err = updateGameStatus(db, game.Slug, winner)
 		if err != nil {
 			l.Errorw("could not update game status", zap.Error(err))
 		}

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -23,13 +23,13 @@ func TestHealthCheckHandler(t *testing.T) {
 
 	for route, handler := range twoHundreds {
 		t.Run(route, func(t *testing.T) {
-			req, err := http.NewRequest(http.MethodGet, route, http.NoBody)
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, route, http.NoBody)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			rr := httptest.NewRecorder()
-			http.HandlerFunc(handler).ServeHTTP(rr, req)
+			handler.ServeHTTP(rr, req)
 
 			if status := rr.Code; status != http.StatusOK {
 				t.Errorf("handler returned wrong status code: got %v want %v",

--- a/cmd/server/openings_test.go
+++ b/cmd/server/openings_test.go
@@ -50,10 +50,10 @@ func TestComputeOpenings(t *testing.T) {
 	//   2: a1, e5, c3, d4
 	//   3: a1, a5, b2 (diverges immediately on move 2)
 	seed := []struct {
-		gameID  int64
-		turn    int64
-		player  int
-		text    string
+		gameID int64
+		turn   int64
+		player int
+		text   string
 	}{
 		{1, 1, gotak.PlayerWhite, "a1"},
 		{1, 1, gotak.PlayerBlack, "e5"},

--- a/cmd/server/replay_test.go
+++ b/cmd/server/replay_test.go
@@ -17,9 +17,9 @@ type scriptedMove struct {
 
 // playGame builds a game by applying the given (player, move) pairs in
 // order. It fails the test if any move is rejected.
-func playGame(t *testing.T, size int64, moves []scriptedMove) *gotak.Game {
+func playGame(t *testing.T, moves []scriptedMove) *gotak.Game {
 	t.Helper()
-	g, err := gotak.NewGame(size, 1, "test")
+	g, err := gotak.NewGame(5, 1, "test")
 	if err != nil {
 		t.Fatalf("NewGame: %v", err)
 	}
@@ -58,7 +58,7 @@ func TestBuildReplaySteps_nilGame(t *testing.T) {
 func TestBuildReplaySteps_firstTurnInversion(t *testing.T) {
 	// On turn 1 each player places the opponent's stone: White's a1
 	// lands as a black stone, Black's e5 lands as a white stone.
-	g := playGame(t, 5, []scriptedMove{
+	g := playGame(t, []scriptedMove{
 		{gotak.PlayerWhite, "a1"},
 		{gotak.PlayerBlack, "e5"},
 	})
@@ -87,7 +87,7 @@ func TestBuildReplaySteps_firstTurnInversion(t *testing.T) {
 }
 
 func TestBuildReplaySteps_snapshotsAreIndependent(t *testing.T) {
-	g := playGame(t, 5, []scriptedMove{
+	g := playGame(t, []scriptedMove{
 		{gotak.PlayerWhite, "a1"},
 		{gotak.PlayerBlack, "e5"},
 		{gotak.PlayerWhite, "b2"},
@@ -112,7 +112,7 @@ func TestBuildReplaySteps_snapshotsAreIndependent(t *testing.T) {
 }
 
 func TestBoardAtTurn(t *testing.T) {
-	g := playGame(t, 5, []scriptedMove{
+	g := playGame(t, []scriptedMove{
 		{gotak.PlayerWhite, "a1"},
 		{gotak.PlayerBlack, "e5"},
 		{gotak.PlayerWhite, "b2"},
@@ -198,7 +198,7 @@ func TestBoardAtTurn_nilGame(t *testing.T) {
 }
 
 func TestSnapshotSquares_isDeepCopy(t *testing.T) {
-	g := playGame(t, 5, []scriptedMove{
+	g := playGame(t, []scriptedMove{
 		{gotak.PlayerWhite, "a1"},
 	})
 	snap := snapshotSquares(g.Board)
@@ -271,7 +271,7 @@ func TestApplyHalfTurn_missingMoveIsNoop(t *testing.T) {
 }
 
 func TestBuildReplaySteps_zipsTimestamps(t *testing.T) {
-	g := playGame(t, 5, []scriptedMove{
+	g := playGame(t, []scriptedMove{
 		{gotak.PlayerWhite, "a1"},
 		{gotak.PlayerBlack, "e5"},
 		{gotak.PlayerWhite, "b2"},
@@ -296,7 +296,7 @@ func TestBuildReplaySteps_zipsTimestamps(t *testing.T) {
 }
 
 func TestBuildReplaySteps_shortTimestampSlice(t *testing.T) {
-	g := playGame(t, 5, []scriptedMove{
+	g := playGame(t, []scriptedMove{
 		{gotak.PlayerWhite, "a1"},
 		{gotak.PlayerBlack, "e5"},
 	})
@@ -359,7 +359,7 @@ func TestLoadMoveTimestamps(t *testing.T) {
 }
 
 func TestReplayStep_zeroPlayedAtIsOmitted(t *testing.T) {
-	g := playGame(t, 5, []scriptedMove{{gotak.PlayerWhite, "a1"}})
+	g := playGame(t, []scriptedMove{{gotak.PlayerWhite, "a1"}})
 	steps, err := buildReplaySteps(g, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/comprehensive_rules_test.go
+++ b/comprehensive_rules_test.go
@@ -313,7 +313,7 @@ func TestCarryLimit(t *testing.T) {
 	}
 
 	// Create a stack of 6 stones (more than board size 5)
-	for i := 0; i < 6; i++ {
+	for range 6 {
 		stone := &Stone{Player: PlayerWhite, Type: StoneFlat}
 		game.Board.Squares["c3"] = append(game.Board.Squares["c3"], stone)
 	}
@@ -409,7 +409,7 @@ func TestStackMovement(t *testing.T) {
 	}
 
 	// Create a stack of 3 stones
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		stone := &Stone{Player: PlayerWhite, Type: StoneFlat}
 		game.Board.Squares["c3"] = append(game.Board.Squares["c3"], stone)
 	}
@@ -449,7 +449,7 @@ func TestStackBreaking(t *testing.T) {
 	}
 
 	// Create a stack of 4 stones
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		stone := &Stone{Player: PlayerWhite, Type: StoneFlat}
 		game.Board.Squares["c3"] = append(game.Board.Squares["c3"], stone)
 	}
@@ -703,7 +703,7 @@ func TestOutOfStonesWin(t *testing.T) {
 
 	// Place exactly the maximum number of stones for white
 	maxStones := game.GetMaxStonesForBoardSize()
-	for i := int64(0); i < maxStones; i++ {
+	for i := range maxStones {
 		row := i / 4
 		col := i % 4
 		square := fmt.Sprintf("%c%d", 'a'+col, row+1)

--- a/game.go
+++ b/game.go
@@ -83,7 +83,7 @@ func (g *Game) GetCapstoneCount() int64 {
 
 // PrintCurrentState is an attempt to render a tak game as text.
 func (g *Game) PrintCurrentState() {
-	_ = g.Board.IterateOverSquares(func(l string, s []*Stone) error {
+	_ = g.Board.IterateOverSquares(func(_ string, s []*Stone) error {
 		fmt.Printf("%v", s)
 		return nil
 	})
@@ -161,7 +161,7 @@ func (g *Game) GameOver() (int, bool) {
 		// Check vertical roads (bottom to top)
 		bottomEdge := []string{}
 		topEdge := []string{}
-		for x := int64(0); x < g.Board.Size; x++ {
+		for x := range g.Board.Size {
 			bottomEdge = append(bottomEdge, letters[x]+"1")
 			topEdge = append(topEdge, letters[x]+strconv.FormatInt(g.Board.Size, 10))
 		}
@@ -187,7 +187,7 @@ func (g *Game) GameOver() (int, bool) {
 	whiteStoneCount := int64(0)
 	blackStoneCount := int64(0)
 
-	err := g.Board.IterateOverSquares(func(location string, stones []*Stone) error {
+	err := g.Board.IterateOverSquares(func(_ string, stones []*Stone) error {
 		if len(stones) > 0 {
 			occupiedSquares++
 			topStone := stones[len(stones)-1]
@@ -431,11 +431,7 @@ func ParsePTN(ptn []byte) (*Game, error) {
 	s := bufio.NewScanner(bytes.NewReader(ptn))
 	for s.Scan() {
 		l := s.Text()
-		ta, err := parseTag(l)
-		if err != nil {
-			return nil, err
-		}
-
+		ta := parseTag(l)
 		if ta != nil {
 			ret.Meta = append(ret.Meta, ta)
 			continue
@@ -530,21 +526,19 @@ func (g *Game) Branches() []string {
 	return out
 }
 
-func parseTag(line string) (*Tag, error) {
-	var tag *Tag
-
+func parseTag(line string) *Tag {
 	// Example: [Tag_Name "Tag Data"]
 	tagRegex := regexp.MustCompile(`\[([0-9A-Za-z_]+) "(.*)"\]`)
 	parts := tagRegex.FindStringSubmatch(line)
 
 	if len(parts) >= 3 {
-		tag = &Tag{
+		return &Tag{
 			Key:   parts[1],
 			Value: parts[2],
 		}
 	}
 
-	return tag, nil
+	return nil
 }
 
 func parseTurn(line string) (*Turn, error) {

--- a/gamelogic_test.go
+++ b/gamelogic_test.go
@@ -164,7 +164,7 @@ func TestCarryLimitEnforcement(t *testing.T) {
 
 	// Create a stack higher than carry limit
 	stones := []*Stone{}
-	for i := 0; i < 7; i++ { // More than board size (5)
+	for range 7 { // More than board size (5)
 		stones = append(stones, &Stone{Player: PlayerWhite, Type: StoneFlat})
 	}
 	game.Board.Squares["c3"] = stones

--- a/move.go
+++ b/move.go
@@ -45,7 +45,7 @@ func IsValidMoveCharacter(char string) bool {
 	}
 
 	// Check for PTN-specific characters: direction markers, stone types
-	return strings.Contains("<>+-SsCcFf", char)
+	return strings.ContainsAny(char, "<>+-SsCcFf")
 }
 
 // Directions

--- a/tps.go
+++ b/tps.go
@@ -110,7 +110,7 @@ func parseTPSStack(cell string) ([]*Stone, error) {
 	}
 
 	stack := make([]*Stone, 0, len(body))
-	for i := 0; i < len(body); i++ {
+	for i := range len(body) {
 		var p int
 		switch body[i] {
 		case '1':


### PR DESCRIPTION
## Summary
The new golangci-lint workflow added a stricter linter set (`bodyclose,misspell,gosec,errorlint,noctx,contextcheck,nilerr,wastedassign,unparam,copyloopvar,intrange,revive,gocritic,unconvert`). The starting run produced 50 findings; this PR fixes all of them so the new lint check passes.

## Changes

Grouped by linter (auto-fix + manual):

- **intrange** (16): `for i := 0; i < n; i++` → `for i := range n` across `ai/engine.go`, `board.go`, `cmd/gotak/main.go`, `game.go`, `tps.go`, and several `_test.go` files.
- **revive** (16):
  - Added package-level comments for `gotak`, `ai`, `cmd/gotak`, `cmd/parse-ptn`, and `cmd/server`.
  - Added doc comments for exported `Beginner`/`Aggressive` const blocks and `TakticianEngine.GetMove` / `TakticianEngine.ExplainMove`.
  - Renamed unused callback parameters to `_` in `IterateOverSquares` callers and other closures.
  - Dropped a redundant `else` branch after a `return` in `cmd/gotak/main.go`.
  - Suppressed one finding (`ai.AIConfig` "stutters") with a documented `//revive:disable-next-line:exported` — renaming `AIConfig` would change the public type used across `cmd/server/{ai,analyze,...}` and several tests.
- **noctx** (10): switched `http.NewRequest` / `httptest.NewRequest` to the `WithContext` variants in `cmd/gotak/main.go`, `cmd/server/auth_test.go`, and `cmd/server/main_test.go`.
- **unparam** (3):
  - `updateGameStatus`: dropped the `status` argument (always `"finished"`) and updated all callers.
  - `playGame` test helper: dropped the `size` argument (always `5`) and updated all callers.
  - `parseTag`: dropped the always-nil `error` return and simplified the one caller.
- **gocritic** (3): cleaned up two `//`-without-space test comments; switched `strings.Contains("<>+-SsCcFf", char)` to `strings.ContainsAny(char, "<>+-SsCcFf")` so the literal/variable argument order is unambiguous.
- **unconvert** (1): removed an unnecessary `http.HandlerFunc(handler)` conversion in `cmd/server/main_test.go`.
- **wastedassign** (1): replaced `boardSize := 0` followed by an unconditional reassignment with `var boardSize int` in `cmd/gotak/main.go`.

`go fmt ./...` also tidied formatting in `cmd/server/openings_test.go`.

## Verification
- `golangci-lint run -E bodyclose,misspell,gosec,errorlint,noctx,contextcheck,nilerr,wastedassign,unparam,copyloopvar,intrange,revive,gocritic,unconvert ./...` — **0 issues**
- `golangci-lint run ./...` (repo `.golangci.yml`, staticcheck) — **0 issues**
- `go build ./...` — passes
- `go test ./...` — passes (`gotak`, `ai`, `cmd/server`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)